### PR TITLE
feat(ops): add compose health checks and networking

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,4 +99,3 @@ volumes:
 
 networks:
   collabsphere:
-    name: collabsphere-local


### PR DESCRIPTION
## Linked Issue

Closes #198
Refs #21
Refs #1

## Summary

- add a shared project-scoped Docker Compose network to the local stack
- add health checks for `postgres`, `redis`, `mailhog`, and optional `minio`
- keep local service port mappings env-configurable through existing compose variables

## Validation

- [x] `docker compose config`
- [x] `docker compose --profile minio config`
- [x] `docker compose up -d --quiet-pull`
- [x] `docker compose ps`
- [x] `docker compose logs postgres --tail 50`
- [x] `docker network inspect collabsphere-repo_collabsphere --format "{{json .Containers}}"`
- [x] `docker compose --profile minio up -d minio --quiet-pull`
- [x] `docker inspect --format "{{json .State.Health}}" collabsphere-repo-minio-1`
- [x] `docker compose --profile minio down`

## Risks / Notes

- health checks rely on binaries present in the selected service images; the pinned MinIO image digest was rechecked locally and includes both `curl` and `mc`

## Handoff

- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

## Handoff Summary

- added a project-scoped shared compose network and service health checks for the local infra stack required by `#198`

## Handoff Validation Evidence

- default and `minio` compose configs rendered successfully
- default services and optional `minio` reached `healthy` status locally
- postgres logs showed successful startup, and network inspection confirmed shared network attachment

## Handoff Open Issues / Follow-ups

- none

## Handoff Risks / Deviations

- none beyond the validated image-binary assumptions used by the health checks

## Review Guidance

- Relevant spec / agent-ref docs: `docs/spec/14-devops/14.2-local-dev-environment.md`, `docs/agent-ref/ops/local-dev.md`, `docs/agent-ref/ops/ci-cd.md`
- Areas that need extra scrutiny: compose healthcheck behavior and network/port configuration consistency with the local-dev workflow