### PR TITLE
docs(ops): document current local setup flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,8 @@ This guide defines the default contribution workflow for CollabSphere. Follow it
 
 ### Prerequisites
 
-- Node.js 22+
-- pnpm 10+
+- Node.js 20 LTS
+- pnpm 9.x
 - Docker Desktop or compatible Docker runtime
 - Git
 
@@ -95,7 +95,7 @@ Health checks after startup:
 - run `docker compose ps` and confirm PostgreSQL, Redis, and MailHog are healthy or running
 - confirm MinIO is healthy too if you enabled the `minio` profile
 - confirm the `pnpm dev` process stays attached without immediate worker or app exits
-- open MailHog at `http://localhost:8025` if enabled locally
+- open MailHog at `http://localhost:8025` if enabled locally, or the port configured through `MAILHOG_UI_PORT`
 - verify the expected local ports are bound before starting implementation work
 
 If startup fails:
@@ -109,6 +109,8 @@ If startup fails:
 ### Common troubleshooting
 
 - Port conflict: update the conflicting port in `.env`, then restart Docker Compose.
+- MailHog UI port conflict: set `MAILHOG_UI_PORT` in `.env`, rerun `docker compose up -d`, then open MailHog on the overridden port.
+- MailHog SMTP port conflict: set `MAILHOG_SMTP_PORT` in `.env`, then restart Docker Compose.
 - Service startup failure: inspect `docker compose ps` first, then check the failing service with `docker compose logs <service>`.
 - Missing env vars: copy missing keys from `.env.example` into the env file used by the affected process, then retry.
 - Stale Docker state: stop services, remove stale containers or volumes if appropriate, then restart.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Notes:
 - Keep app runtime-only overrides in `.env.local`; do not commit it.
 - If a default port is already in use, update the matching `*_PORT` value in `.env` before starting Compose.
 - MailHog UI is available at `http://localhost:8025` with the default ports.
+- If `8025` is already in use, set `MAILHOG_UI_PORT` in `.env`, then rerun `docker compose up -d`.
+- If the SMTP port `1025` conflicts locally, set `MAILHOG_SMTP_PORT` in `.env` before restarting Compose.
 
 ### Need more detail?
 


### PR DESCRIPTION
## Linked Issue

Closes #200
Refs #21
Refs #1

## Summary

- add a real local-development section to `README.md` with prerequisites, Docker Compose startup steps, service verification, and optional MinIO usage
- align `CONTRIBUTING.md` to the current repo startup flow by documenting Docker service startup before `pnpm dev`
- tighten troubleshooting for service startup failures, MailHog port overrides, and port conflicts without introducing future startup-orchestration behavior
- align onboarding prerequisites to the canonical Node.js 20 LTS / pnpm 9.x local-dev references

## Validation

- [x] `Select-String -Path README.md -Pattern "Local Development|Node.js 20|pnpm 9|MAILHOG_UI_PORT|MAILHOG_SMTP_PORT|docker compose|MailHog|MinIO"`
- [x] `Select-String -Path CONTRIBUTING.md -Pattern "Node.js 20|pnpm 9|docker compose|Port conflict|Service startup failure|MAILHOG_UI_PORT|MAILHOG_SMTP_PORT|MinIO"`
- [x] `git diff --stat`

## Risks / Notes

- docs intentionally describe the current repo behavior (`docker compose up -d` plus `pnpm dev`) instead of a future one-command startup path that is not implemented in this checkout

## Handoff

- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

## Handoff Summary

- documented the current local setup flow in `README.md` and aligned `CONTRIBUTING.md` troubleshooting with the actual Docker Compose based startup sequence
- aligned local setup prerequisites to the canonical Node.js 20 LTS / pnpm 9.x requirement and added explicit MailHog port override guidance

## Handoff Validation Evidence

- README now contains a local development section with Docker Compose steps, service notes, and explicit MailHog override variables
- CONTRIBUTING now contains explicit Compose startup, prerequisite alignment, MinIO notes, and startup troubleshooting entries
- task diff remains limited to `README.md` and `CONTRIBUTING.md`

## Handoff Open Issues / Follow-ups

- none

## Handoff Risks / Deviations

- docs reflect the current repo state rather than the future single-command startup story

## Review Guidance

- Relevant spec / agent-ref docs: `docs/spec/14-devops/14.2-local-dev-environment.md`, `docs/agent-ref/ops/local-dev.md`
- Areas that need extra scrutiny: consistency between `README.md`, `CONTRIBUTING.md`, and the current Docker Compose based local setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified prerequisites and adjusted recommended Node/pnpm versions.
  * Renamed “One-command startup” to “Current startup flow” and expanded startup steps to separate infrastructure bring-up from app execution.
  * Added optional MinIO startup via Compose profile and expanded health checks.
  * Clarified MailHog UI/SMTP port guidance and added explicit service-failure diagnostics with retry instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->