### PR TITLE
docs(ops): align contributing startup guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,11 +112,12 @@ Health checks after startup:
 ### Common troubleshooting
 
 - Missing `.env`: copy `.env.example` to `.env`, then rerun `pnpm dev`.
+- Missing required env keys: add the reported keys to `.env`, using `.env.example` as the reference, then rerun `pnpm dev`.
 - Invalid env values: fix the reported key in `.env` or `.env.local`, using `.env.example` as the reference, then rerun `pnpm dev`.
 - Docker not running or Compose startup failure: verify Docker is running, rerun `pnpm dev`, and inspect the reported `docker compose` failure before retrying.
 - Port conflict: update the conflicting port in `.env`, then rerun `pnpm dev` so Docker Compose restarts with the override.
-- MailHog UI port conflict: set `MAILHOG_UI_PORT` in `.env`, then rerun `pnpm dev` or restart Docker Compose before opening MailHog on the overridden port.
-- MailHog SMTP port conflict: set `MAILHOG_SMTP_PORT` in `.env`, then rerun `pnpm dev` or restart Docker Compose if you are reusing services with `--skip-compose`.
+- MailHog UI port conflict: set `MAILHOG_UI_PORT` in `.env`, then rerun `pnpm dev`. If you are reusing services with `pnpm dev --skip-compose`, manually restart Docker Compose or the MailHog container before opening MailHog on the overridden port.
+- MailHog SMTP port conflict: set `MAILHOG_SMTP_PORT` in `.env`, then rerun `pnpm dev`. If you are reusing services with `pnpm dev --skip-compose`, manually restart Docker Compose or the MailHog container before testing SMTP on the overridden port.
 - Already-running services: use `pnpm dev --skip-compose` when you intentionally want to reuse a healthy existing Docker Compose session instead of restarting it.
 - Service startup failure: inspect `docker compose ps` first, then check the failing service with `docker compose logs <service>`.
 - Stale Docker state: stop services, remove stale containers or volumes if appropriate, then restart.


### PR DESCRIPTION
## Linked Issue

Closes #205

## Summary

- update `CONTRIBUTING.md` so `pnpm dev` is the primary one-command local startup path
- document the real `scripts/dev.mjs` behavior: env validation first, Docker Compose startup by default, app startup afterward, and `--skip-compose` for reusing healthy services
- align troubleshooting to current runtime behavior for missing `.env`, missing required env keys, invalid env values, Docker/Compose failures, port conflicts, MailHog port reuse, and already-running services

## Validation

- [x] `Select-String -Path CONTRIBUTING.md -Pattern "Missing required env keys|MailHog UI port conflict|MailHog SMTP port conflict|pnpm dev --skip-compose|Docker not running or Compose startup failure"`
- [x] `Select-String -Path scripts/dev.mjs -Pattern "Missing required local environment keys|Use \.env.example as the reference and keep \.env in sync|Copy \.env.example to \.env before running pnpm dev|skipping docker compose startup because --skip-compose was provided"`
- [x] `git diff -- CONTRIBUTING.md`

## Risks / Notes

- Scope stays on `CONTRIBUTING.md` only; this PR does not change runtime behavior.
- The guide now reflects the current merged orchestrator on `main` rather than the older manual two-step startup flow.
- Optional MinIO startup remains documented as a separate compose-profile step because `pnpm dev` does not enable that profile automatically.

## Handoff

- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

## Handoff Summary

- `#205` brings `CONTRIBUTING.md` into line with the current one-command startup behavior already present on `main`, including the review-driven troubleshooting clarifications for missing env keys and MailHog port overrides.

## Handoff Validation Evidence

- Recorded doc-to-code alignment checks on the linked issue, including the missing-key remediation path, `pnpm dev` versus `--skip-compose` restart behavior, and the matching `scripts/dev.mjs` env messages.

## Handoff Open Issues / Follow-ups

- Further documentation cleanup outside `CONTRIBUTING.md` should be handled separately if needed.

## Handoff Risks / Deviations

- This PR intentionally does not widen into README or runtime code changes.

## Review Guidance

- Relevant docs: `docs/spec/14-devops/14.2-local-dev-environment.md`, `docs/agent-ref/ops/local-dev.md`
- Review focus: whether `CONTRIBUTING.md` now matches the current `scripts/dev.mjs` startup and troubleshooting behavior without describing unsupported flows

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rick1330/collabsphere/pull/1445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified getting started: `pnpm dev` is now the primary command and automatically validates the environment and starts Docker services
  * Added `--skip-compose` flag option for reusing already-running services
  * Enhanced troubleshooting guide with comprehensive setup failure guidance and remediation steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->