### PR TITLE
docs(ops): align branch protection checks

### DIFF
--- a/docs/agent-ref/ops/branch-protection.md
+++ b/docs/agent-ref/ops/branch-protection.md
@@ -43,7 +43,7 @@ Enable and require these exact current check names on `main`:
 
 Do not mark these as universal required checks in branch protection:
 
-- `Queue Manifest Validate / validate`, because it is path-scoped to `.github/queue/**` changes and will not run on ordinary delivery PRs
+- `Queue Manifest Validate / validate`, because it is path-scoped to queue-manifest surfaces (`.github/queue/**`, `.github/scripts/validate_queue_manifest.rb`, and `.github/workflows/queue-manifest-validate.yml`) and will not run on ordinary delivery PRs
 - third-party review integrations such as `CodeRabbit`, `DeepScan`, or `CodeScene Code Health Review (main)` unless repo policy explicitly promotes them to required status checks later
 
 ### Require branches to be up to date before merging


### PR DESCRIPTION
## Summary
- align `docs/agent-ref/ops/branch-protection.md` to the current post-`#206`/`#207` check surface on `main`
- document the exact required branch-protection checks for `main`, including CI job names plus `Handoff Check`, `PR Status Sync`, and `Review Router`
- clarify the manual GitHub settings step and explicitly note that `Queue Manifest Validate / validate` is path-scoped and should not be selected as a universal required check

## Validation
- `Select-String -Path docs/agent-ref/ops/branch-protection.md -Pattern 'CI / lint|CI / typecheck|CI / unit-tests|CI / integration-tests|CI / build-web|CI / build-api|CI / build-collab|CI / build-worker|Handoff Check / validate|PR Status Sync / sync|Review Router / route|Queue Manifest Validate / validate|CodeRabbit|DeepScan|CodeScene Code Health Review \(main\)'`
- `gh pr view 1449 --json statusCheckRollup`
- `git diff -- docs/agent-ref/ops/branch-protection.md`

## Risks / Notes
- branch protection remains a manual GitHub settings step; this PR documents the exact current rule but does not apply repository settings automatically
- Docker layer caching and CI workflow changes remain out of scope for `#208`
- the informational Devin comments on merged PR `#1449` did not reveal a current correctness bug on `main`, so they did not change the scope or conclusion here

## Handoff Summary
- updated the branch-protection reference to match the current required checks on `main`
- replaced stale future-tense guidance about application CI with the exact current `CI / <job>` names now shipped by `#206` and `#207`
- documented which checks should not be configured as universal required checks in branch protection

## Handoff Validation Evidence
- `Select-String -Path docs/agent-ref/ops/branch-protection.md -Pattern 'CI / lint|CI / typecheck|CI / unit-tests|CI / integration-tests|CI / build-web|CI / build-api|CI / build-collab|CI / build-worker|Handoff Check / validate|PR Status Sync / sync|Review Router / route|Queue Manifest Validate / validate|CodeRabbit|DeepScan|CodeScene Code Health Review \(main\)'`
- `gh pr view 1449 --json statusCheckRollup`
- `git diff -- docs/agent-ref/ops/branch-protection.md`

## Handoff Open Issues / Follow-ups
- applying the documented branch protection rule in GitHub UI still requires a manual maintainer step
- later story work still owns any broader CI hardening beyond the required-check documentation

## Handoff Risks / Deviations
- this task documents the current required checks but cannot prove the GitHub UI rule is applied until a maintainer updates repository settings

## Issue
Closes #208

## Handoff
- [x] Handoff added to the linked issue or parent story
- [ ] Handoff not required for this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rick1330/collabsphere/pull/1450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated branch protection guidance with an expanded, explicit list of required status checks (lint, typecheck, unit/integration tests and build jobs).
  * Clarified that some checks should not be made universally required (path-scoped or third-party review checks).
  * Improved verification steps: match exact workflow/job names in GitHub's UI and confirm the specific legacy check is not selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->