### PR TITLE
docs(ops): align contributing CI guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,7 +261,7 @@ For docs-only changes, validate by checking the expected files and key sections 
 
 ## CI and Required Checks
 
-`main` is now branch-protected against the repo-owned merge gate checks. GitHub currently enforces the raw check identities emitted by the workflows, so ordinary delivery PRs must pass these exact required checks before merge:
+`main` is branch-protected with required CI job checks and repo-owned merge gate checks. GitHub currently enforces the raw check identities emitted by the workflows, so ordinary delivery PRs must pass these exact required checks before merge:
 
 - `lint`
 - `typecheck`


### PR DESCRIPTION
## Summary
- update `CONTRIBUTING.md` so the CI section matches the current post-`#206`/`#207`/`#208` branch-protection state on `main`
- document the exact raw required checks now enforced by branch protection: `lint`, `typecheck`, `unit-tests`, `integration-tests`, `build-web`, `build-api`, `build-collab`, `build-worker`, `validate`, `sync`, and `route`
- explain how those check names map back to the current workflow files and local troubleshooting steps

## Validation
- `Select-String -Path CONTRIBUTING.md -Pattern 'GitHub currently enforces the raw check identities|`lint`|`typecheck`|`unit-tests`|`integration-tests`|`build-web`|`build-api`|`build-collab`|`build-worker`|`validate`|`sync`|`route`|\.github/workflows/ci.yml|\.github/workflows/handoff-check.yml|\.github/workflows/pr-status-sync.yml|\.github/workflows/review-router.yml|Queue Manifest Validate / validate|docker compose up -d postgres redis|docker compose ps'`
- `git diff -- CONTRIBUTING.md`
- `gh api repos/Rick1330/collabsphere/branches/main/protection --jq ".required_status_checks.contexts"`

## Risks / Notes
- docs-only change; no CI workflow or GitHub settings changes in this PR
- third-party review integrations remain informational in the docs because current branch protection only enforces repo-owned checks
- `docs/agent-ref/ops/branch-protection.md` on `main` still uses the old prefixed names and needs a separate follow-up outside `#209`

## Handoff Summary
- aligned `CONTRIBUTING.md` to the live branch-protection state after maintenance fix `#1452`
- replaced the stale prefixed required-check names with the actual raw check identities GitHub currently enforces on ordinary delivery PRs
- clarified which workflow files emit those checks so contributors can map `lint`/`typecheck`/`validate`/`sync`/`route` back to the correct workflow when troubleshooting
- kept the earlier local integration-test parity guidance that uses `docker compose up -d postgres redis` and `docker compose ps`

## Handoff Validation Evidence
- `Select-String -Path CONTRIBUTING.md -Pattern 'GitHub currently enforces the raw check identities|`lint`|`typecheck`|`unit-tests`|`integration-tests`|`build-web`|`build-api`|`build-collab`|`build-worker`|`validate`|`sync`|`route`|\.github/workflows/ci.yml|\.github/workflows/handoff-check.yml|\.github/workflows/pr-status-sync.yml|\.github/workflows/review-router.yml|Queue Manifest Validate / validate|docker compose up -d postgres redis|docker compose ps'`
- `git diff -- CONTRIBUTING.md`
- `gh api repos/Rick1330/collabsphere/branches/main/protection --jq ".required_status_checks.contexts"`

## Handoff Open Issues / Follow-ups
- `#210` and `#1168` still remain for the rest of story `#23`
- `docs/agent-ref/ops/branch-protection.md` still needs separate alignment to the raw enforced check names after `#1452`
- if branch protection or CI workflow names change later, `CONTRIBUTING.md` must be updated in the same change

## Handoff Risks / Deviations
- this task documents the current enforced check surface on `main`; it does not change CI workflow behavior

## Issue
Closes #209

## Handoff
- [x] Handoff added to the linked issue or parent story
- [ ] Handoff not required for this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guide to run validation/build commands from the repo root and added explicit local integration startup via Docker Compose plus service verification.
  * Replaced a generic CI checklist with an explicit branch-protection style list covering lint/typecheck, per-suite unit/integration tests, per-app builds, and repository-owned merge gates.
  * Clarified which workflow checks are path-scoped versus universally required.
  * Expanded troubleshooting for integration-test and required-check failures, including verifying failing check names against the documented required checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->