### PR TITLE
fix(ops): bind MailHog to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,8 +54,8 @@ services:
     image: mailhog/mailhog:v1.0.1
     restart: unless-stopped
     ports:
-      - "${MAILHOG_SMTP_PORT:-1025}:1025"
-      - "${MAILHOG_UI_PORT:-8025}:8025"
+      - "127.0.0.1:${MAILHOG_SMTP_PORT:-1025}:1025"
+      - "127.0.0.1:${MAILHOG_UI_PORT:-8025}:8025"
     networks:
       - collabsphere
     healthcheck:


### PR DESCRIPTION
## Linked Issue

Closes #215

## Summary

- tighten the existing MailHog compose service to localhost-only host bindings
- keep the existing SMTP/UI env-var port overrides and health check intact
- validate that MailHog starts healthy with the new bindings and then stop it again

## Validation

- [x] `docker compose -f docker-compose.yml config`
- [x] `docker compose -f docker-compose.yml up -d mailhog`
- [x] `docker compose -f docker-compose.yml ps mailhog`
- [x] `docker compose -f docker-compose.yml stop mailhog`

## Risks / Notes

- current `main` already contained the MailHog service, ports, and health check; this PR completes the remaining localhost-only binding requirement

## Handoff

- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

## Handoff Summary

- `#215` handoff comment posted with the localhost-binding change and validation evidence
- story `#25` continuity comment posted for PR-open state

## Handoff Validation Evidence

- `docker compose -f docker-compose.yml config`
- `docker compose -f docker-compose.yml up -d mailhog`
- `docker compose -f docker-compose.yml ps mailhog`
- observed healthy state with `127.0.0.1:1025->1025/tcp, 127.0.0.1:8025->8025/tcp`
- `docker compose -f docker-compose.yml stop mailhog`

## Handoff Open Issues / Follow-ups

- none

## Handoff Risks / Deviations

- task scope was narrower than the original issue wording implied because MailHog had already been added before this pass

## Review Guidance

- Relevant spec / agent-ref docs: `docs/spec/14-devops/14.2-local-dev-environment.md`, `docs/agent-ref/ops/local-dev.md`, `docs/agent-ref/ops/env-vars.md`
- Areas that need extra scrutiny: confirm localhost-only bindings are the right final shape for local-only MailHog exposure
