### PR TITLE
docs(ops): document MailHog local SMTP flow (#217)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,8 @@
 # Never commit `.env.local`.
 #
 # Values below match the current `docker-compose.yml` defaults and the canonical
-# local-development env contracts from `docs/spec/07-architecture/07.5-*` and
+# local-development env contracts from
+# `docs/spec/07-architecture/07.5-config-environments.md` and
 # `docs/spec/14-devops/14.3-*`.
 
 # Docker Compose infrastructure defaults
@@ -55,7 +56,8 @@ REFRESH_TOKEN_TTL_DAYS=7
 # placeholder unless you are intentionally testing a real email provider.
 EMAIL_PROVIDER_API_KEY=replace-with-local-email-key
 # Local-only SMTP overrides for MailHog-backed dev email routing. These are not
-# part of the canonical required env list in `docs/spec/07-architecture/07.5-*`;
+# part of the canonical required env list in
+# `docs/spec/07-architecture/07.5-config-environments.md`;
 # keep them unset unless you need to override `pnpm dev` defaults (`127.0.0.1`
 # + `MAILHOG_SMTP_PORT`).
 # EMAIL_SMTP_HOST=127.0.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ Use these steps when you need to verify outbound email behavior locally without 
 3. If you need explicit SMTP overrides, set local-only `EMAIL_SMTP_HOST` and `EMAIL_SMTP_PORT` in `.env` or `.env.local` (for example `127.0.0.1` and `1025`).
 4. Trigger an app flow that sends email, then verify the message appears in MailHog.
 
-`EMAIL_SMTP_HOST` and `EMAIL_SMTP_PORT` are local-development-only overrides and are not part of the canonical required env list in `docs/spec/07-architecture/07.5-*`.
+`EMAIL_SMTP_HOST` and `EMAIL_SMTP_PORT` are local-development-only overrides and are not part of the canonical required env list in `docs/spec/07-architecture/07.5-config-environments.md`.
 
 ### Common troubleshooting
 


### PR DESCRIPTION
## Linked Issue

Closes #217

## Summary

- clarify `.env.example` note that `EMAIL_SMTP_HOST` and `EMAIL_SMTP_PORT` are local-only and non-canonical
- add a dedicated `MailHog local email flow` section in `CONTRIBUTING.md`
- document how to run local MailHog email checks and where SMTP overrides belong

## Validation

- [x] `rg -n "EMAIL_SMTP_HOST|EMAIL_SMTP_PORT|MAILHOG|MailHog" .env.example CONTRIBUTING.md` (unavailable locally: `rg` not installed)
- [x] `Select-String -Path .env.example,CONTRIBUTING.md -Pattern "EMAIL_SMTP_HOST|EMAIL_SMTP_PORT|MAILHOG|MailHog"`

## Risks / Notes

- none

## Handoff

- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

## Handoff Summary

- `.env.example` and `CONTRIBUTING.md` now explicitly document MailHog local SMTP usage for local email testing.

## Handoff Validation Evidence

- `Select-String -Path .env.example,CONTRIBUTING.md -Pattern "EMAIL_SMTP_HOST|EMAIL_SMTP_PORT|MAILHOG|MailHog"`

## Handoff Open Issues / Follow-ups

- none

## Handoff Risks / Deviations

- `rg` command from issue validation could not run in this environment because `rg` is not installed; equivalent `Select-String` output verified the required docs markers.

## Review Guidance

- Relevant spec / agent-ref docs: `docs/spec/07-architecture/07.5-config-environments.md`, `docs/spec/14-devops/14.2-local-dev-environment.md`, `docs/agent-ref/ops/env-vars.md`
- Areas that need extra scrutiny: ensure local-only SMTP language does not imply production usage

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rick1330/collabsphere/pull/1466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added step-by-step local MailHog email testing to the contributor guide, including how to start services, access the MailHog UI, and verify messages.
  * Updated environment example comments to point to the canonical env spec, clarified MailHog SMTP override wording, and noted SMTP override vars are not part of the canonical required env list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->