### PR TITLE
docs(ops): add health-check endpoint and LB probe reference (#220)

### DIFF
--- a/docs/agent-ref/ops/health-checks.md
+++ b/docs/agent-ref/ops/health-checks.md
@@ -90,9 +90,10 @@ readinessProbe:
     port: 3001
   initialDelaySeconds: 5
   periodSeconds: 10
-  timeoutSeconds: 2
+  timeoutSeconds: 3
   failureThreshold: 3
 ```
+- Keep readiness `timeoutSeconds` higher than the app probe timeout budget so the process can return structured `503` payloads instead of transport timeouts.
 
 ### Kubernetes liveness probe guidance
 - Do **not** use dependency-aware `/api/v1/health` as `livenessProbe`, because dependency outages can trigger restart loops.


### PR DESCRIPTION
## Summary
- add `docs/agent-ref/ops/health-checks.md` covering `/api/v1/health` behavior
- document response schema, status codes (`200`/`503`), and `requestId` contract (`meta.requestId` + `x-request-id`)
- document timeout behavior introduced in `#219` (default 2s budget, `HEALTH_CHECK_TIMEOUT_MS`)
- add load balancer probe examples (cURL, Kubernetes, NGINX)

## Scope
- implements only `#220` docs scope
- no runtime behavior changes
- no CI workflow changes (`#221` out of scope)

## Validation
- `Test-Path docs/agent-ref/ops/health-checks.md`
- `Select-String -Path docs/agent-ref/ops/health-checks.md -Pattern "/api/v1/health|requestId|503|load balancer|probe"`

## Handoff
- [x] Handoff added to the linked issue or parent story
- [ ] Handoff not required for this PR

Closes #220
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rick1330/collabsphere/pull/1469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the health check API endpoint, detailing response format, dependency validation (Postgres and Redis), HTTP status codes, configurable timeout behavior, and integration examples for load balancers and Kubernetes deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->