### PR TITLE
chore(repo): refine turbo cache invalidation inputs (#223)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -4,16 +4,14 @@
     "pnpm-lock.yaml",
     "pnpm-workspace.yaml",
     "tsconfig.base.json",
-    "packages/shared/**"
+    "packages/shared/src/**",
+    "packages/shared/package.json",
+    "packages/shared/tsconfig.json"
   ],
   "tasks": {
     "build": {
       "dependsOn": [
         "^build"
-      ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "packages/shared/**"
       ],
       "outputs": [
         "dist/**",
@@ -27,28 +25,16 @@
     "lint": {
       "dependsOn": [
         "^lint"
-      ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "packages/shared/**"
       ]
     },
     "typecheck": {
       "dependsOn": [
         "^typecheck"
-      ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "packages/shared/**"
       ]
     },
     "test": {
       "dependsOn": [
         "^test"
-      ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "packages/shared/**"
       ],
       "outputs": [
         "coverage/**"


### PR DESCRIPTION
## Linked Issue

Closes #223

## Summary

- Finalized Turborepo cache invalidation configuration for CS-007-2 with concise, root-level shared-package dependency tracking.
- Removed ineffective workspace-relative task input glob usage and simplified configuration ownership.

## Changes

- Updated `turbo.json` only.
- Added/kept root `globalDependencies` for workspace/config inputs.
- Narrowed shared invalidation scope to:
  - `packages/shared/src/**`
  - `packages/shared/package.json`
  - `packages/shared/tsconfig.json`
- Removed redundant task-level `inputs` entries that referenced `packages/shared/**`.

## Validation

- [x] `node -e "JSON.parse(require('node:fs').readFileSync('turbo.json','utf8')); console.log('turbo.json valid')"`
- [x] `pnpm build`
- [x] `pnpm test`

## Risks / Notes

- none

## Handoff

- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

## Handoff Summary

- `turbo.json` now has single-source, narrower shared invalidation with no redundant per-task shared glob entries.

## Handoff Validation Evidence

- Build and test pipelines pass on final merged head.
- Review thread on invalid task inputs was resolved with docs-backed rationale.

## Handoff Open Issues / Follow-ups

- none

## Handoff Risks / Deviations

- none

## Review Guidance

- Relevant spec / agent-ref docs:
  - `docs/spec/07-architecture/07.4-repo-organization.md`
  - `docs/agent-ref/ops/ci-cd.md`
  - `https://turborepo.dev/docs/reference/configuration`
- Areas that need extra scrutiny:
  - cache invalidation scope when shared package structure changes

## Audit Note

- Automated reviewer outputs remain in PR comments for traceability.