### PR TITLE
chore(ops): add Vercel config for static web deploy (#227)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,6 @@
   "framework": null,
   "buildCommand": "pnpm --filter @collabsphere/web run build",
   "outputDirectory": "apps/web/dist",
-  "cleanUrls": true,
   "trailingSlash": false,
   "redirects": [
     {


### PR DESCRIPTION
## Linked Issue

Closes #227

## Summary

- add a root `vercel.json` for the current static `apps/web` deployment surface
- configure Vercel to build only `@collabsphere/web` and serve `apps/web/dist`
- add a canonical redirect from `/index.html` to `/`

## Validation

- [x] `Test-Path vercel.json`
- [x] `Get-Content -Raw vercel.json | ConvertFrom-Json`
- [x] `pnpm --filter @collabsphere/web run build`
- [x] `Get-ChildItem apps/web/dist`

## Risks / Notes

- current `apps/web` output is a minimal static artifact, not a Next.js runtime surface
- no runtime environment variables are required by the current static output
- Vercel project-side verification remains manual because the repo is not linked via `.vercel` and only `VERCEL_API_KEY` is available locally

## Handoff

- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

## Handoff Summary

- `#227` now has a truthful `vercel.json` for the static web artifact produced after `#1476`

## Handoff Validation Evidence

- `vercel.json` parses as valid JSON
- `pnpm --filter @collabsphere/web run build` still emits `apps/web/dist/index.html`

## Handoff Open Issues / Follow-ups

- manual dashboard verification still required: confirm the Vercel project uses the repo root, runs the configured build command, and serves `apps/web/dist`

## Handoff Risks / Deviations

- none

## Review Guidance

- Relevant spec / agent-ref docs:
  - `docs/spec/14-devops/14.6-deployment-strategy.md`
  - `docs/agent-ref/ops/deployment.md`
- Areas that need extra scrutiny:
  - whether the config stays strictly aligned to the current static `apps/web` surface

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rick1330/collabsphere/pull/1478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added deployment configuration for improved URL routing and handling, enabling cleaner URLs without query parameters and trailing slashes on the hosted application. Configured proper redirects for optimized user navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->