### PR TITLE
fix(ops): restore deploy artifact staging for backend images (#1485)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -188,7 +188,7 @@ jobs:
 
           for service in api collab web worker; do
             artifact_dir="$(
-              find "$artifact_root" -path "*/${service}/dist" -type d | head -n 1
+              find "$artifact_root" -path "*/${service}/dist" -type d -print -quit
             )"
 
             if [[ -z "$artifact_dir" ]]; then


### PR DESCRIPTION
## Linked Issue

Closes #1485

## Summary

- restore the deploy job artifact handoff so downloaded build outputs are staged back into `apps/<service>/dist`
- keep the backend Docker build contract aligned with `infra/azure/container-apps/backend-service.Dockerfile`
- leave the migrations-job follow-up in `#1483` separate from this workflow defect fix

## Validation

- [x] `Get-Content .github/workflows/deploy.yml | ConvertFrom-Yaml | Out-Null`
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @collabsphere/web run build`
- [x] `pnpm --filter @collabsphere/api run build`
- [x] `pnpm --filter @collabsphere/collab run build`
- [x] `pnpm --filter @collabsphere/worker run build`
- [x] artifact-restaging simulation restored `apps/api/dist`, `apps/collab/dist`, `apps/worker/dist`, and `apps/web/dist`
- [x] `docker build --file infra/azure/container-apps/backend-service.Dockerfile --build-arg APP_DIR=apps/api --tag collabsphere-api-local:test .`

## Risks / Notes

- this PR fixes the artifact/build-context mismatch that fails `Build and push backend images`; it does not solve the separate migrations-job workflow gap tracked in `#1483`
- I did not trigger a live `Deploy` workflow on this branch because the workflow contains `Verify deploy ref is already on main`, which would fail for an unmerged branch head by design

## Handoff

- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

## Handoff Summary

- staging deploys on `main` were failing because the deploy job downloaded artifacts but did not restage them into the workspace layout required by `COPY ${APP_DIR}/dist/ ./`
- the deploy job now restores each downloaded `dist` directory into `apps/<service>/dist` before backend image builds run

## Handoff Validation Evidence

- failing run inspected: `23898773673`
- failing lines from the live log:
  - `COPY apps/api/dist/ ./`
  - `ERROR: "/apps/api/dist": not found`
- local docker validation now reaches the same `COPY apps/api/dist/ ./` step successfully

## Handoff Open Issues / Follow-ups

- `#1483` remains open for the migrations-job workflow gap
- `#231` stays blocked until a post-merge deploy run proves the workflow advances far enough to justify smoke-test work

## Handoff Risks / Deviations

- no live staging deploy was executed from this branch because the workflow intentionally gates deploy refs to commits already on `main`

## Review Guidance

- Relevant spec / agent-ref docs: `.github/workflows/deploy.yml`, `infra/azure/container-apps/backend-service.Dockerfile`
- Areas that need extra scrutiny: artifact download layout, restaging step portability, and whether the deploy job now preserves the Docker build context expected by each backend service

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rick1330/collabsphere/pull/1486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved deployment artifact staging and validation to ensure service build artifacts are placed correctly before deployment.
  * Added per-service checks that fail early when a service build is missing, preventing incomplete deployments.
  * Ensures staged build outputs are reliably copied into the application directories for consistent release behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->