### PR TITLE
fix(ops): handle Vercel-protected staging smoke tests (#1490)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ env:
   NODE_VERSION: 20.19.4
   PNPM_VERSION: 9.15.9
   TURBO_TELEMETRY_DISABLED: "1"
+  VERCEL_CLI_VERSION: 50.38.3
 
 concurrency:
   group: deploy-${{ github.workflow }}-${{ github.ref_type == 'tag' && 'production' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment) || 'staging' }}
@@ -578,6 +579,10 @@ jobs:
           printf '%s\n' "$deployment_url"
 
           echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
+
+      - name: Install Vercel CLI for smoke tests
+        shell: bash
+        run: npm install --global "vercel@${VERCEL_CLI_VERSION}"
 
       - name: Run post-deploy smoke tests
         timeout-minutes: 10

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -11,6 +11,8 @@ delay_seconds="${SMOKE_TEST_DELAY_SECONDS:-5}"
 connect_timeout_seconds="${SMOKE_TEST_CONNECT_TIMEOUT_SECONDS:-5}"
 max_time_seconds="${SMOKE_TEST_MAX_TIME_SECONDS:-15}"
 tmp_root="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+web_url_is_vercel_deployment="false"
+web_url_request_path="/"
 
 require_positive_integer() {
   local name="$1"
@@ -26,6 +28,11 @@ usage() {
   cat <<'EOF'
 Usage:
   API_HEALTH_URL=<url> WEB_URL=<url> bash scripts/smoke-test.sh
+
+Notes:
+  - `node` is required for backend health payload validation.
+  - If `WEB_URL` targets a protected `.vercel.app` deployment, `VERCEL_TOKEN`
+    and the `vercel` CLI on PATH are also required.
 EOF
 }
 
@@ -39,6 +46,24 @@ require_positive_integer "SMOKE_TEST_ATTEMPTS" "$attempts"
 require_positive_integer "SMOKE_TEST_DELAY_SECONDS" "$delay_seconds"
 require_positive_integer "SMOKE_TEST_CONNECT_TIMEOUT_SECONDS" "$connect_timeout_seconds"
 require_positive_integer "SMOKE_TEST_MAX_TIME_SECONDS" "$max_time_seconds"
+
+initialize_web_probe_contract() {
+  local metadata
+
+  metadata="$(
+    node -e '
+      const candidate = process.argv[1];
+      const parsed = new URL(candidate);
+      const isVercel = parsed.hostname.endsWith(".vercel.app") ? "true" : "false";
+      const requestPath = `${parsed.pathname || "/"}${parsed.search || ""}` || "/";
+      process.stdout.write(`${isVercel}\t${requestPath}`);
+    ' "$web_url"
+  )"
+
+  IFS=$'\t' read -r web_url_is_vercel_deployment web_url_request_path <<<"$metadata"
+}
+
+initialize_web_probe_contract
 
 work_dir="$(mktemp -d "${tmp_root}/collabsphere-smoke-XXXXXX")"
 trap 'rm -rf "$work_dir"' EXIT
@@ -60,25 +85,11 @@ probe_url() {
     "$url"
 }
 
-is_vercel_deployment_url() {
-  local url="$1"
-
-  node -e '
-    const candidate = process.argv[1];
-    try {
-      const parsed = new URL(candidate);
-      process.exit(parsed.hostname.endsWith(".vercel.app") ? 0 : 1);
-    } catch {
-      process.exit(1);
-    }
-  ' "$url"
-}
-
 probe_web_url() {
   local body_path="$1"
   local headers_path="$2"
 
-  if ! is_vercel_deployment_url "$web_url"; then
+  if [[ "$web_url_is_vercel_deployment" != "true" ]]; then
     probe_url "$web_url" "$body_path" "$headers_path"
     return
   fi
@@ -88,7 +99,12 @@ probe_web_url() {
     return 1
   fi
 
-  local cmd=(pnpm dlx vercel curl / --yes --deployment "$web_url" --token "$vercel_token")
+  if ! command -v vercel >/dev/null 2>&1; then
+    echo "vercel CLI is required to smoke-test protected Vercel deployment URLs." >&2
+    return 1
+  fi
+
+  local cmd=(vercel curl "$web_url_request_path" --yes --deployment "$web_url" --token "$vercel_token")
   if [[ -n "$vercel_scope" ]]; then
     cmd+=(--scope "$vercel_scope")
   fi


### PR DESCRIPTION
## Linked Issue

Closes #1490

## Summary

- switch the web smoke-test probe to `vercel curl` when the target URL is a protected `.vercel.app` deployment
- pass the existing Vercel deploy token and scope into the smoke-test step instead of introducing a new bypass secret
- keep backend health probing unchanged while preserving the existing bounded retry and timeout behavior

## Validation

- [x] `gh run view 23917312925 --json databaseId,displayTitle,conclusion,url,jobs`
- [x] `gh run view 23917312925 --job 69754484671 --log-failed`
- [x] `pnpm dlx vercel curl --help`
- [x] `bash -n scripts/smoke-test.sh`
- [x] `git diff --check -- .github/workflows/deploy.yml scripts/smoke-test.sh`

## Risks / Notes

- local end-to-end execution against a live protected Vercel deployment was not reproduced from this checkout; the fix is validated against the failed run facts and the current Vercel CLI contract
- no new GitHub environment secret or variable is introduced in this PR

## Handoff

- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

## Handoff Summary

- corrected the staging web smoke-test contract so CI probes the protected Vercel deployment through a documented protection-aware path instead of anonymous `curl`

## Handoff Validation Evidence

- `gh run view 23917312925 --json databaseId,displayTitle,conclusion,url,jobs`
- `gh run view 23917312925 --job 69754484671 --log-failed`
- `pnpm dlx vercel curl --help`
- `bash -n scripts/smoke-test.sh`
- `git diff --check -- .github/workflows/deploy.yml scripts/smoke-test.sh`

## Handoff Open Issues / Follow-ups

- none

## Handoff Risks / Deviations

- story continuity comment `4177860141` on `#28` was edited only to fix broken markdown rendering and preserve the original historical facts

## Review Guidance

- Relevant spec / agent-ref docs: `DEPLOYMENT.md`, `docs/agent-ref/ops/deployment.md`, `docs/agent-ref/ops/ci-cd.md`
- Areas that need extra scrutiny: Vercel-protected preview probing via `vercel curl` and the env contract passed into `Run post-deploy smoke tests`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rick1330/collabsphere/pull/1491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced post-deployment smoke testing: CI now installs and pins the Vercel CLI and exposes additional environment variables to enable authenticated verification of Vercel-hosted deployments. Smoke tests now detect Vercel URLs and require CLI/token tooling and a runtime check, failing fast if prerequisites are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->