### PR TITLE
fix(deploy): fail fast on invalid Vercel token and add rollover fallback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -262,26 +262,34 @@ jobs:
             label="${token_labels[$index]}"
             token="${token_values[$index]}"
 
-            if pnpm dlx "vercel@${VERCEL_CLI_VERSION}" whoami --token "$token" >/dev/null 2>&1; then
+            if auth_output="$(pnpm dlx "vercel@${VERCEL_CLI_VERSION}" whoami --token "$token" 2>&1)"; then
               selected_label="$label"
               selected_token="$token"
               break
             fi
 
-            echo "::warning::${label} failed Vercel auth preflight for ${DEPLOY_ENVIRONMENT}; trying next configured token (if any)."
+            if echo "$auth_output" | grep -Eiq "(not valid|invalid token|authentication failed|unauthorized|\\b401\\b)"; then
+              echo "::warning::${label} failed Vercel auth preflight for ${DEPLOY_ENVIRONMENT}; trying next configured token (if any)."
+              continue
+            fi
+
+            echo "::error::Vercel auth preflight encountered a non-token error while validating ${label} for ${DEPLOY_ENVIRONMENT}: ${auth_output}"
+            exit 1
           done
 
           if [[ -z "$selected_token" ]]; then
-            echo "::error::No configured Vercel token passed authentication preflight. Rotate VERCEL_TOKEN for the ${DEPLOY_ENVIRONMENT} environment."
+            echo "::error::No configured Vercel token passed authentication preflight. Rotate or update all configured Vercel token secrets (for example, VERCEL_TOKEN and VERCEL_TOKEN_ROLLOVER) for the ${DEPLOY_ENVIRONMENT} environment."
             exit 1
           fi
 
           echo "::add-mask::$selected_token"
-          echo "VERCEL_TOKEN=$selected_token" >> "$GITHUB_ENV"
           echo "token_source=$selected_label" >> "$GITHUB_OUTPUT"
+          echo "vercel_token=$selected_token" >> "$GITHUB_OUTPUT"
 
       - name: Validate Vercel project access
         shell: bash
+        env:
+          VERCEL_TOKEN: ${{ steps.vercel-token.outputs.vercel_token }}
         run: |
           set -euo pipefail
 
@@ -290,7 +298,23 @@ jobs:
             exit 1
           fi
 
-          pnpm dlx "vercel@${VERCEL_CLI_VERSION}" pull --yes --environment="$VERCEL_ENVIRONMENT" --token "$VERCEL_TOKEN" >/dev/null
+          vercel_project_api_url="https://api.vercel.com/v9/projects/${VERCEL_PROJECT_ID}?teamId=${VERCEL_ORG_ID}"
+          vercel_project_response="$RUNNER_TEMP/vercel-project-access.json"
+          if ! vercel_http_status="$(
+            curl --silent --show-error --output "$vercel_project_response" --write-out "%{http_code}" \
+              --header "Authorization: Bearer ${VERCEL_TOKEN}" \
+              "$vercel_project_api_url"
+          )"; then
+            echo "::error::Vercel project access preflight failed due to network/transport error while validating ${DEPLOY_ENVIRONMENT}."
+            exit 1
+          fi
+
+          if [[ "$vercel_http_status" != "200" ]]; then
+            response_preview="$(head -c 200 "$vercel_project_response" | tr '\n' ' ')"
+            echo "::error::Unable to access Vercel project ${VERCEL_PROJECT_ID} in org/team ${VERCEL_ORG_ID} (HTTP ${vercel_http_status}). ${response_preview}"
+            exit 1
+          fi
+
           echo "Using ${DEPLOY_ENVIRONMENT} Vercel token source: ${{ steps.vercel-token.outputs.token_source }}"
 
       - name: Validate required deployment contracts
@@ -314,6 +338,9 @@ jobs:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
           AZURE_ACR_PASSWORD: ${{ secrets.AZURE_ACR_PASSWORD }}
+          VERCEL_TOKEN_PRIMARY: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TOKEN_ROLLOVER: ${{ secrets.VERCEL_TOKEN_ROLLOVER }}
+          RESOLVED_VERCEL_TOKEN: ${{ steps.vercel-token.outputs.vercel_token }}
         run: |
           set -euo pipefail
 
@@ -352,7 +379,12 @@ jobs:
             fi
           done
 
-          if [[ -z "${VERCEL_TOKEN:-}" ]]; then
+          if [[ -z "${VERCEL_TOKEN_PRIMARY:-}" && -z "${VERCEL_TOKEN_ROLLOVER:-}" ]]; then
+            echo "::error::At least one Vercel token secret (VERCEL_TOKEN or VERCEL_TOKEN_ROLLOVER) is required for deploy.yml."
+            exit 1
+          fi
+
+          if [[ -z "${RESOLVED_VERCEL_TOKEN:-}" ]]; then
             echo "::error::Resolved Vercel token is missing. Ensure the Resolve and validate Vercel token step runs before contract validation."
             exit 1
           fi
@@ -596,22 +628,24 @@ jobs:
       - name: Deploy web to Vercel
         id: deploy-web
         shell: bash
+        env:
+          VERCEL_TOKEN: ${{ steps.vercel-token.outputs.vercel_token }}
         run: |
           set -euo pipefail
           deploy_stdout="$RUNNER_TEMP/vercel-deploy.out"
           deploy_stderr="$RUNNER_TEMP/vercel-deploy.err"
 
-          pnpm dlx vercel pull --yes --environment="$VERCEL_ENVIRONMENT" --token "$VERCEL_TOKEN"
+          pnpm dlx "vercel@${VERCEL_CLI_VERSION}" pull --yes --environment="$VERCEL_ENVIRONMENT" --token "$VERCEL_TOKEN"
 
           if [[ "$DEPLOY_ENVIRONMENT" == "production" ]]; then
-            pnpm dlx vercel build --prod --token "$VERCEL_TOKEN"
-            if ! pnpm dlx vercel deploy --prebuilt --prod --token "$VERCEL_TOKEN" >"$deploy_stdout" 2>"$deploy_stderr"; then
+            pnpm dlx "vercel@${VERCEL_CLI_VERSION}" build --prod --token "$VERCEL_TOKEN"
+            if ! pnpm dlx "vercel@${VERCEL_CLI_VERSION}" deploy --prebuilt --prod --token "$VERCEL_TOKEN" >"$deploy_stdout" 2>"$deploy_stderr"; then
               cat "$deploy_stderr"
               exit 1
             fi
           else
-            pnpm dlx vercel build --token "$VERCEL_TOKEN"
-            if ! pnpm dlx vercel deploy --prebuilt --token "$VERCEL_TOKEN" >"$deploy_stdout" 2>"$deploy_stderr"; then
+            pnpm dlx "vercel@${VERCEL_CLI_VERSION}" build --token "$VERCEL_TOKEN"
+            if ! pnpm dlx "vercel@${VERCEL_CLI_VERSION}" deploy --prebuilt --token "$VERCEL_TOKEN" >"$deploy_stdout" 2>"$deploy_stderr"; then
               cat "$deploy_stderr"
               exit 1
             fi
@@ -657,6 +691,7 @@ jobs:
           API_HEALTH_URL: ${{ steps.backend-smoke-target.outputs.api_health_url }}
           WEB_URL: ${{ steps.deploy-web.outputs.deployment_url }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ steps.vercel-token.outputs.vercel_token }}
         run: bash scripts/smoke-test.sh
 
   notify:

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -99,15 +99,18 @@ Deploy-time configuration for `staging` is expected in GitHub Actions environmen
 - `AZURE_TENANT_ID`
 - `AZURE_SUBSCRIPTION_ID`
 - `AZURE_ACR_PASSWORD`
-- `VERCEL_TOKEN`
 - `DEPLOY_NOTIFICATION_WEBHOOK_URL`
 
-#### Optional GitHub environment secrets for token rollover safety
+#### Required GitHub environment secrets for Vercel authentication
 
+At least one of the following secrets must be configured:
+
+- `VERCEL_TOKEN`
+  - primary token
 - `VERCEL_TOKEN_ROLLOVER`
-  - optional fallback token used when `VERCEL_TOKEN` fails deploy-time Vercel auth preflight
+  - optional fallback token for rotation windows and emergency recoveries
 
-The deploy workflow now validates Vercel token auth (`vercel whoami`) and project access (`vercel pull`) before Azure deployment mutation steps. If both configured tokens fail, the run exits early with a token-rotation error.
+The deploy workflow validates token auth (`vercel whoami`) and project access (Vercel project API) before Azure deployment mutation steps. If both configured tokens fail auth preflight, the run exits early with a token-rotation error.
 
 The deploy workflow posts a compact Discord notification after each staging or production run using the environment-scoped `DEPLOY_NOTIFICATION_WEBHOOK_URL` secret.
 


### PR DESCRIPTION
## Linked Issue

Closes #1504

## Summary

- add a deploy-job preflight that validates Vercel auth before Azure mutation steps
- support optional environment secret `VERCEL_TOKEN_ROLLOVER` and auto-fallback when primary token is invalid
- run Vercel project access preflight (`vercel pull`) early and propagate only the resolved valid token to deploy + smoke-test steps
- update deployment docs with rollover-token contract and fail-fast behavior

## Validation

- [x] `gh run view 23998577138 --log-failed` (confirmed failure root cause: invalid Vercel token)
- [x] `pnpm lint`

## Risks / Notes

- environments should add `VERCEL_TOKEN_ROLLOVER` only when a staged rollover token is available
- if both tokens are invalid, deploy now fails earlier (before backend mutation), which is intentional

## Handoff

- [x] Handoff not required for this PR
- [ ] Handoff added to the linked issue or parent story

## Handoff Summary

- none

## Handoff Validation Evidence

- none

## Handoff Open Issues / Follow-ups

- rotate the current invalid `staging` `VERCEL_TOKEN` secret before next deploy

## Handoff Risks / Deviations

- none

## Review Guidance

- Relevant spec / agent-ref docs: `DEPLOYMENT.md`, `.github/workflows/deploy.yml`
- Areas that need extra scrutiny: token preflight/fallback flow and secret-handling behavior in logs

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rick1330/collabsphere/pull/1505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment pipeline with authentication validation and token rotation support
  * Deployments now verify Vercel access before proceeding with mutations
* **Documentation**
  * Updated deployment configuration guide with token rollover options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->