### PR TITLE
[MAINT] Migrate story-project-gates tests to TypeScript with runtime-safe JS exceptions

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,0 +1,20 @@
+# GitHub Script Runtime Notes
+
+## TypeScript migration status
+
+- `story-project-gates.test.ts` is TypeScript-backed and runs via `tsx --test`.
+- `story-project-gates.js` is intentionally retained as handwritten JavaScript.
+
+## Explicit handwritten-JS exceptions
+
+### `story-project-gates.js`
+
+- Runtime owner: `.github/workflows/story-project-gates.yml` via `actions/github-script`.
+- Constraint: the workflow executes on clean runners without `pnpm install`, so TypeScript loaders are not available by default.
+- Decision: keep the gate-evaluation module as CommonJS JavaScript to avoid introducing loader/bootstrap dependencies into issue-gate automation.
+
+### `eslint.config.mjs`
+
+- Runtime owner: `pnpm lint` (ESLint flat config entrypoint).
+- Constraint: converting config to TypeScript would require extra runtime loading for lint startup.
+- Decision: keep `.mjs` for deterministic lint invocation and minimal tooling coupling.

--- a/.github/scripts/story-project-gates.js
+++ b/.github/scripts/story-project-gates.js
@@ -1,3 +1,12 @@
+/**
+ * Intentionally retained as CommonJS JavaScript.
+ *
+ * This module is loaded directly by `actions/github-script` in
+ * `.github/workflows/story-project-gates.yml` via `require(...)` on a clean
+ * runner that does not install repo dependencies. Keeping this file as plain
+ * JS avoids introducing a TypeScript loader/bootstrap dependency into
+ * gate-enforcement automation.
+ */
 function labelNames(issue) {
   return (issue.labels || [])
     .map((label) => (typeof label === "string" ? label : label.name))

--- a/.github/scripts/story-project-gates.test.ts
+++ b/.github/scripts/story-project-gates.test.ts
@@ -1,14 +1,45 @@
-const test = require("node:test");
-const assert = require("node:assert/strict");
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test from "node:test";
 
+type Issue = {
+  state?: string;
+  labels: Array<{ name: string }>;
+};
+
+type ValidationGate = {
+  allTerminal: boolean;
+  validationDone: boolean;
+  validationStatus: string;
+};
+
+type ParentGate = ValidationGate & {
+  parentStatus: string | null;
+  parentState: string | null;
+};
+
+type Scenario<TExpected> = {
+  name: string;
+  children: Issue[];
+  validation: Issue;
+  parent?: Issue;
+  expected: TExpected;
+};
+
+const require = createRequire(import.meta.url);
 const {
   evaluateParentGate,
   evaluateValidationGate,
   statusLabel,
   terminal,
-} = require("./story-project-gates");
+} = require("./story-project-gates.js") as {
+  evaluateParentGate: (children: Issue[], validation: Issue, parent: Issue) => ParentGate;
+  evaluateValidationGate: (children: Issue[], validation: Issue) => ValidationGate;
+  statusLabel: (issue: Issue) => string | null;
+  terminal: (issue: Issue) => boolean;
+};
 
-function issue(status, extras = {}) {
+function issue(status: string | string[], extras: Partial<Issue> = {}): Issue {
   const statuses = Array.isArray(status) ? status : [status];
   return {
     state: "open",
@@ -17,7 +48,7 @@ function issue(status, extras = {}) {
   };
 }
 
-const validationScenarios = [
+const validationScenarios: Array<Scenario<ValidationGate>> = [
   {
     name: "becomes ready when all implementation children are terminal",
     children: [issue("status:done"), issue("status:cancelled")],
@@ -60,7 +91,7 @@ const validationScenarios = [
   },
 ];
 
-const parentScenarios = [
+const parentScenarios: Array<Scenario<ParentGate>> = [
   {
     name: "validated parent remains done and closed when cancelled children exist",
     children: [issue("status:done"), issue("status:cancelled")],
@@ -141,7 +172,11 @@ const parentScenarios = [
   },
 ];
 
-async function runScenarioSubtests(t, scenarios, evaluate) {
+async function runScenarioSubtests<TExpected>(
+  t: test.TestContext,
+  scenarios: Array<Scenario<TExpected>>,
+  evaluate: (scenario: Scenario<TExpected>) => TExpected,
+): Promise<void> {
   for (const scenario of scenarios) {
     await t.test(scenario.name, () => {
       assert.deepEqual(evaluate(scenario), scenario.expected);
@@ -170,6 +205,6 @@ test("evaluateParentGate preserves cancelled parents and only mutates when requi
   await runScenarioSubtests(
     t,
     parentScenarios,
-    (scenario) => evaluateParentGate(scenario.children, scenario.validation, scenario.parent),
+    (scenario) => evaluateParentGate(scenario.children, scenario.validation, scenario.parent!),
   );
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,8 @@ import js from "@eslint/js";
 import globals from "globals";
 import tsParser from "@typescript-eslint/parser";
 
+// Intentionally kept as .mjs because ESLint's flat-config entrypoint is native ESM.
+// Switching this file to TypeScript would require loader/bootstrap coupling for lint.
 export default [
   {
     ignores: [
@@ -70,6 +72,7 @@ export default [
       "packages/**/*.ts",
       "tests/**/*.ts",
       "apps/**/test/**/*.ts",
+      ".github/scripts/**/*.ts",
     ],
     languageOptions: {
       ...js.configs.recommended.languageOptions,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "pnpm exec eslint . --max-warnings=0",
     "typecheck": "pnpm exec tsc -p packages/shared/tsconfig.json --noEmit",
     "test": "pnpm exec turbo run //#test:unit && pnpm exec turbo run //#test:integration --env-mode=loose",
-    "test:unit": "pnpm exec tsx --test .github/scripts/story-project-gates.test.js tests/unit/api-bootstrap-env.test.ts tests/unit/api-email-config.test.ts tests/unit/ci-workflow.test.ts tests/unit/collab-worker-bootstrap-env.test.ts tests/unit/integration-fixtures.test.ts tests/unit/shared-env.test.ts",
+    "test:unit": "pnpm exec tsx --test .github/scripts/story-project-gates.test.ts tests/unit/api-bootstrap-env.test.ts tests/unit/api-email-config.test.ts tests/unit/ci-workflow.test.ts tests/unit/collab-worker-bootstrap-env.test.ts tests/unit/integration-fixtures.test.ts tests/unit/shared-env.test.ts",
     "test:integration": "node --test tests/integration",
     "build": "pnpm exec turbo run build",
     "build:web": "pnpm --filter @collabsphere/web run build",


### PR DESCRIPTION
## Linked Issue

Closes #1499

## Summary

- migrate `.github/scripts/story-project-gates.test.js` to TypeScript as `.github/scripts/story-project-gates.test.ts`
- keep `.github/scripts/story-project-gates.js` as a deliberate CommonJS exception because `actions/github-script` requires direct `require(...)` without a TypeScript loader bootstrap
- document retained handwritten-JS exceptions in `.github/scripts/README.md` (including `eslint.config.mjs` rationale)
- extend lint coverage to include `.github/scripts/**/*.ts` and update `test:unit` to the new TS test path

## Validation

- [x] `node --test .github/scripts/story-project-gates.test.js` (baseline before edits)
- [x] `pnpm exec tsx --test .github/scripts/story-project-gates.test.ts`
- [x] `pnpm lint`
- [x] `node -e "const gates=require('./.github/scripts/story-project-gates'); ..."` (workflow `require()` contract check)
- [x] `pnpm test:unit`

## Risks / Notes

- `.github/scripts/story-project-gates.js` remains JS by design to preserve GitHub Actions runtime determinism on clean runners
- `eslint.config.mjs` remains an explicit ESM config exception to avoid adding lint loader coupling

## Handoff

- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

## Handoff Summary

- completed the runtime-safe `#1499` migration decision by moving gate tests to TS while preserving the workflow runtime script in CJS JS with explicit exception rationale

## Handoff Validation Evidence

- validation commands and outcomes are listed above

## Handoff Open Issues / Follow-ups

- none

## Handoff Risks / Deviations

- no workflow invocation change was required; `story-project-gates.yml` still resolves `require(.../story-project-gates)`

## Review Guidance

- Relevant spec / agent-ref docs: `docs/agent-ref/ops/github-issue-lifecycle.md`, `docs/agent-ref/ops/review-automation.md`, `.github/workflows/story-project-gates.yml`
- Areas that need extra scrutiny: JS exception rationale for gate runtime path and TS test runner compatibility under `tsx --test`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rick1330/collabsphere/pull/1506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added GitHub Actions script execution documentation.

* **Tests**
  * Migrated test suite to TypeScript for enhanced type safety.
  * Updated test command to execute TypeScript test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->