### PR TITLE
fix: align Vercel root and Next tracing for prebuilt deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -540,7 +540,6 @@ jobs:
 
       - name: Deploy web to Vercel
         id: deploy-web
-        working-directory: apps/web
         shell: bash
         env:
           VERCEL_TOKEN: ${{ steps.vercel-token.outputs.vercel_token }}

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -44,7 +44,7 @@ The staging backend is bootstrapped and healthy in Azure, and the recovered GitH
 
 - Hosted on Vercel
 - `apps/web` is now a Next.js App Router application foundation
-- The deploy workflow builds and deploys the web app from `apps/web` using Vercel CLI and the app-local [apps/web/vercel.json](./apps/web/vercel.json) contract
+- The deploy workflow builds and deploys the web app from the repo root using Vercel CLI against the project `rootDirectory` `apps/web` and the app-local [apps/web/vercel.json](./apps/web/vercel.json) contract
 - Upload/download build artifacts remain backend-only (`api`, `collab`, `worker`); the web deploy no longer depends on a staged `apps/web/dist` artifact
 - Staging deploys from `main` use Vercel preview mode
 - Production deploys use `vercel build --prod` followed by `vercel deploy --prebuilt --prod`

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,5 +1,11 @@
+import { fileURLToPath } from "node:url";
+
+const outputFileTracingRoot = fileURLToPath(new URL("../../", import.meta.url));
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Trace from the monorepo root so prebuilt Vercel deploys include hoisted runtime files.
+  outputFileTracingRoot,
   reactStrictMode: true,
   eslint: {
     // Repo-wide lint runs from the root flat config; avoid duplicate Next lint passes during build.


### PR DESCRIPTION
## Linked Issue

Closes #1513

## Summary

- align the Vercel deploy step with the live monorepo contract by running the CLI from the repo root instead of `apps/web`
- set `outputFileTracingRoot` in `apps/web/next.config.mjs` so Next traces hoisted monorepo runtime files for prebuilt deploys
- update deployment docs to match the corrected repo-root Vercel CLI + `apps/web` root-directory contract

## Validation

- [x] `pnpm --filter @collabsphere/web run build`
- [x] inspected `apps/web/.next/required-server-files.json` to confirm `outputFileTracingRoot` resolves to the repo root

## Risks / Notes

- live Vercel project `anchorpipelab/collabsphere` was corrected out-of-band to `framework=nextjs`, `rootDirectory=apps/web`, `sourceFilesOutsideRootDirectory=true`, and `nodeVersion=20.x`; this PR makes the repo contract match that live project truth
- local Windows `vercel build` still shows a route-to-lambda packaging quirk, but the GitHub Linux runner was already succeeding at `vercel build` and failing later during prebuilt deployment ingestion, so the relevant regression for this PR is the root-directory / tracing mismatch

## Handoff

- [x] Handoff not required for this PR
- [ ] Handoff added to the linked issue or parent story

## Handoff Summary

- none

## Handoff Validation Evidence

- none

## Handoff Open Issues / Follow-ups

- after merge, rerun or observe the `Deploy` workflow on `main` to confirm the prebuilt Vercel path gets past the previous `ENOENT` failure

## Handoff Risks / Deviations

- none

## Review Guidance

- Relevant spec / agent-ref docs: `DEPLOYMENT.md`, `docs/spec/14-devops/14.6-deployment-strategy.md`, `docs/spec/07-architecture/07.2-tech-stack.md`
- Areas that need extra scrutiny: monorepo Vercel CLI invocation path, Next output file tracing root, and whether the merged repo contract now matches the live Vercel project settings
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rick1330/collabsphere/pull/1514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions deployment workflow configuration to optimize build and deployment process execution from repository root
  * Enhanced Next.js build configuration with improved file tracing and output handling capabilities during deployment
  * Updated deployment documentation to reflect configuration changes and modified workflow procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->