### PR TITLE
feat(web): follow system theme preference (#241)

### DIFF
--- a/apps/web/src/components/theme/theme-provider.tsx
+++ b/apps/web/src/components/theme/theme-provider.tsx
@@ -36,16 +36,17 @@ type ThemeMediaQueryListLike = {
   matches: boolean;
   addEventListener?: (
     type: "change",
-    listener: (event: ThemeMediaQueryListLike) => void,
+    listener: (event: ThemeMediaQueryChangeEventLike) => void,
   ) => void;
   removeEventListener?: (
     type: "change",
-    listener: (event: ThemeMediaQueryListLike) => void,
+    listener: (event: ThemeMediaQueryChangeEventLike) => void,
   ) => void;
-  addListener?: (listener: (event: ThemeMediaQueryListLike) => void) => void;
-  removeListener?: (listener: (event: ThemeMediaQueryListLike) => void) => void;
+  addListener?: (listener: (event: ThemeMediaQueryChangeEventLike) => void) => void;
+  removeListener?: (listener: (event: ThemeMediaQueryChangeEventLike) => void) => void;
 };
 
+type ThemeMediaQueryChangeEventLike = Pick<ThemeMediaQueryListLike, "matches">;
 type ThemeMediaQueryWindow = Pick<Window, "matchMedia">;
 type ThemeToggleTimer = ReturnType<typeof setTimeout>;
 type ThemeToggleScheduler = typeof setTimeout;
@@ -73,7 +74,7 @@ const getInitialThemePreference = (): ThemePreference => {
 };
 
 export const resolveSystemTheme = (
-  mediaQueryList: Pick<ThemeMediaQueryListLike, "matches"> | null | undefined,
+  mediaQueryList: ThemeMediaQueryChangeEventLike | null | undefined,
 ): ResolvedTheme => (mediaQueryList?.matches ? "dark" : "light");
 
 export const readSystemTheme = (
@@ -100,11 +101,9 @@ export const subscribeToSystemTheme = (
 
   try {
     const mediaQueryList = windowLike.matchMedia(systemThemeMediaQuery);
-    const handleChange = (event: ThemeMediaQueryListLike) => {
+    const handleChange = (event: ThemeMediaQueryChangeEventLike) => {
       onSystemThemeChange(resolveSystemTheme(event));
     };
-
-    onSystemThemeChange(resolveSystemTheme(mediaQueryList));
 
     if (typeof mediaQueryList.addEventListener === "function") {
       mediaQueryList.addEventListener("change", handleChange);
@@ -145,15 +144,19 @@ export const ThemeProvider = ({ children }: PropsWithChildren) => {
   const toggleTimerRef = useRef<ThemeToggleTimer | null>(null);
   const [themeState, setThemeState] = useState<ThemeProviderState>(() => ({
     preference: getInitialThemePreference(),
-    systemTheme: defaultResolvedTheme,
+    systemTheme:
+      typeof window === "undefined" ? defaultResolvedTheme : readSystemTheme(window),
   }));
   const { preference, systemTheme } = themeState;
   const resolvedTheme = resolveThemePreference(preference, systemTheme);
 
   useEffect(() => {
     applyThemePreference(document, preference, systemTheme);
-    writeStoredThemePreference(getSafeLocalStorage(), preference);
   }, [preference, systemTheme]);
+
+  useEffect(() => {
+    writeStoredThemePreference(getSafeLocalStorage(), preference);
+  }, [preference]);
 
   useEffect(() => {
     return subscribeToSystemTheme(

--- a/tests/unit/web-theme-provider.test.ts
+++ b/tests/unit/web-theme-provider.test.ts
@@ -20,6 +20,15 @@ import {
   type ThemePreference,
 } from "../../apps/web/src/lib/theme";
 
+const themeValues = {
+  light: "light",
+  dark: "dark",
+  system: "system",
+} as const;
+
+type ThemeMode = keyof typeof themeValues;
+type MediaQueryApi = "modern" | "legacy";
+
 class MemoryStorage {
   #store = new Map<string, string>();
 
@@ -32,51 +41,46 @@ class MemoryStorage {
   }
 }
 
-class ModernMediaQueryList {
+class FakeMediaQueryList {
   matches: boolean;
   listener: ((event: { matches: boolean }) => void) | null = null;
+  addEventListener?:
+    | ((_type: "change", listener: (event: { matches: boolean }) => void) => void)
+    | undefined;
+  removeEventListener?:
+    | ((_type: "change", listener: (event: { matches: boolean }) => void) => void)
+    | undefined;
+  addListener?: ((listener: (event: { matches: boolean }) => void) => void) | undefined;
+  removeListener?: ((listener: (event: { matches: boolean }) => void) => void) | undefined;
 
-  constructor(matches: boolean) {
+  constructor(api: MediaQueryApi, matches: boolean) {
     this.matches = matches;
-  }
 
-  addEventListener(_type: "change", listener: (event: { matches: boolean }) => void) {
-    this.listener = listener;
-  }
-
-  removeEventListener(_type: "change", listener: (event: { matches: boolean }) => void) {
-    if (this.listener === listener) {
-      this.listener = null;
+    if (api === "modern") {
+      this.addEventListener = (_type, listener) => {
+        this.listener = listener;
+      };
+      this.removeEventListener = (_type, listener) => {
+        if (this.listener === listener) {
+          this.listener = null;
+        }
+      };
+      return;
     }
+
+    this.addListener = (listener) => {
+      this.listener = listener;
+    };
+    this.removeListener = (listener) => {
+      if (this.listener === listener) {
+        this.listener = null;
+      }
+    };
   }
 
-  dispatch(matches: boolean) {
-    this.matches = matches;
-    this.listener?.({ matches });
-  }
-}
-
-class LegacyMediaQueryList {
-  matches: boolean;
-  listener: ((event: { matches: boolean }) => void) | null = null;
-
-  constructor(matches: boolean) {
-    this.matches = matches;
-  }
-
-  addListener(listener: (event: { matches: boolean }) => void) {
-    this.listener = listener;
-  }
-
-  removeListener(listener: (event: { matches: boolean }) => void) {
-    if (this.listener === listener) {
-      this.listener = null;
-    }
-  }
-
-  dispatch(matches: boolean) {
-    this.matches = matches;
-    this.listener?.({ matches });
+  dispatch(nextMatches: boolean) {
+    this.matches = nextMatches;
+    this.listener?.({ matches: nextMatches });
   }
 }
 
@@ -94,6 +98,45 @@ const createThemeDocument = () => ({
   },
 });
 
+const createWindowLike = (mediaQueryList: FakeMediaQueryList) => ({
+  matchMedia(query: string) {
+    assert.equal(query, systemThemeMediaQuery);
+    return mediaQueryList;
+  },
+});
+
+const createSubscriptionHarness = ({
+  api,
+  initialTheme,
+}: {
+  api: MediaQueryApi;
+  initialTheme: ThemeMode;
+}) => {
+  const observedThemes: ThemeMode[] = [];
+  const mediaQueryList = new FakeMediaQueryList(api, initialTheme === themeValues.dark);
+  const cleanup = subscribeToSystemTheme(createWindowLike(mediaQueryList), (theme) => {
+    observedThemes.push(theme);
+  });
+
+  return {
+    cleanup,
+    mediaQueryList,
+    observedThemes,
+  };
+};
+
+const assertResolvedTheme = ({
+  preference,
+  expected,
+  systemTheme,
+}: {
+  preference: ThemePreference;
+  expected: ThemeMode;
+  systemTheme?: "light" | "dark";
+}) => {
+  assert.equal(resolveThemePreference(preference, systemTheme), expected);
+};
+
 test("readStoredThemePreference defaults to system when storage is empty or invalid", () => {
   const storage = new MemoryStorage();
 
@@ -106,35 +149,39 @@ test("readStoredThemePreference defaults to system when storage is empty or inva
 test("writeStoredThemePreference persists supported theme values for later reads", () => {
   const storage = new MemoryStorage();
 
-  for (const preference of ["light", "dark", "system"] satisfies ThemePreference[]) {
+  for (const preference of Object.values(themeValues)) {
     writeStoredThemePreference(storage, preference);
     assert.equal(readStoredThemePreference(storage), preference);
   }
 });
 
 test("resolveThemePreference keeps explicit choices and falls back to light for system", () => {
-  assert.equal(resolveThemePreference("light"), "light");
-  assert.equal(resolveThemePreference("dark"), "dark");
-  assert.equal(resolveThemePreference("system"), defaultResolvedTheme);
-  assert.equal(resolveThemePreference("system", "dark"), "dark");
-  assert.equal(resolveThemePreference("light", "dark"), "light");
-  assert.equal(resolveThemePreference("dark", "light"), "dark");
+  assertResolvedTheme({ preference: themeValues.light, expected: themeValues.light });
+  assertResolvedTheme({ preference: themeValues.dark, expected: themeValues.dark });
+  assertResolvedTheme({
+    preference: themeValues.system,
+    expected: defaultResolvedTheme,
+  });
+  assertResolvedTheme({
+    preference: themeValues.system,
+    systemTheme: themeValues.dark,
+    expected: themeValues.dark,
+  });
+  assertResolvedTheme({
+    preference: themeValues.light,
+    systemTheme: themeValues.dark,
+    expected: themeValues.light,
+  });
+  assertResolvedTheme({
+    preference: themeValues.dark,
+    systemTheme: themeValues.light,
+    expected: themeValues.dark,
+  });
 });
 
 test("readSystemTheme reads the current OS preference and falls back safely", () => {
-  const darkWindow = {
-    matchMedia(query: string) {
-      assert.equal(query, systemThemeMediaQuery);
-      return new ModernMediaQueryList(true);
-    },
-  };
-
-  const lightWindow = {
-    matchMedia(query: string) {
-      assert.equal(query, systemThemeMediaQuery);
-      return new ModernMediaQueryList(false);
-    },
-  };
+  const darkWindow = createWindowLike(new FakeMediaQueryList("modern", true));
+  const lightWindow = createWindowLike(new FakeMediaQueryList("modern", false));
 
   const throwingWindow = {
     matchMedia() {
@@ -142,69 +189,53 @@ test("readSystemTheme reads the current OS preference and falls back safely", ()
     },
   };
 
-  assert.equal(readSystemTheme(darkWindow), "dark");
-  assert.equal(readSystemTheme(lightWindow), "light");
+  assert.equal(readSystemTheme(darkWindow), themeValues.dark);
+  assert.equal(readSystemTheme(lightWindow), themeValues.light);
   assert.equal(readSystemTheme(throwingWindow), defaultResolvedTheme);
   assert.equal(readSystemTheme(null), defaultResolvedTheme);
 });
 
-test("subscribeToSystemTheme initializes from matchMedia and reacts to modern change events", () => {
-  const observedThemes: string[] = [];
-  const mediaQueryList = new ModernMediaQueryList(true);
-  const windowLike = {
-    matchMedia(query: string) {
-      assert.equal(query, systemThemeMediaQuery);
-      return mediaQueryList;
-    },
-  };
+for (const scenario of [
+  {
+    api: "modern",
+    changeTheme: themeValues.light,
+    initialTheme: themeValues.dark,
+    name: "subscribeToSystemTheme reacts to modern change events and removes listeners on cleanup",
+  },
+  {
+    api: "legacy",
+    changeTheme: themeValues.dark,
+    initialTheme: themeValues.light,
+    name: "subscribeToSystemTheme supports legacy media-query listeners and removes them on cleanup",
+  },
+] as const) {
+  test(scenario.name, () => {
+    const { cleanup, mediaQueryList, observedThemes } = createSubscriptionHarness(scenario);
 
-  const cleanup = subscribeToSystemTheme(windowLike, (theme) => {
-    observedThemes.push(theme);
+    assert.deepEqual(observedThemes, []);
+
+    mediaQueryList.dispatch(scenario.changeTheme === themeValues.dark);
+    assert.deepEqual(observedThemes, [scenario.changeTheme]);
+
+    cleanup();
+    assert.equal(mediaQueryList.listener, null);
+
+    mediaQueryList.dispatch(scenario.initialTheme === themeValues.dark);
+    assert.deepEqual(observedThemes, [scenario.changeTheme]);
   });
-
-  assert.deepEqual(observedThemes, ["dark"]);
-
-  mediaQueryList.dispatch(false);
-  assert.deepEqual(observedThemes, ["dark", "light"]);
-
-  cleanup();
-  assert.equal(mediaQueryList.listener, null);
-});
-
-test("subscribeToSystemTheme supports legacy media-query listeners and removes them on cleanup", () => {
-  const observedThemes: string[] = [];
-  const mediaQueryList = new LegacyMediaQueryList(false);
-  const windowLike = {
-    matchMedia(query: string) {
-      assert.equal(query, systemThemeMediaQuery);
-      return mediaQueryList;
-    },
-  };
-
-  const cleanup = subscribeToSystemTheme(windowLike, (theme) => {
-    observedThemes.push(theme);
-  });
-
-  assert.deepEqual(observedThemes, ["light"]);
-
-  mediaQueryList.dispatch(true);
-  assert.deepEqual(observedThemes, ["light", "dark"]);
-
-  cleanup();
-  assert.equal(mediaQueryList.listener, null);
-});
+}
 
 test("getNextThemePreference uses a stable light-dark-system cycle for downstream toggle UIs", () => {
-  assert.equal(getNextThemePreference("system"), "light");
-  assert.equal(getNextThemePreference("light"), "dark");
-  assert.equal(getNextThemePreference("dark"), "system");
+  assert.equal(getNextThemePreference(themeValues.system), themeValues.light);
+  assert.equal(getNextThemePreference(themeValues.light), themeValues.dark);
+  assert.equal(getNextThemePreference(themeValues.dark), themeValues.system);
 });
 
 test("queueThemeToggle debounces rapid theme toggles and only keeps the latest pending commit", () => {
   let nextTimerId = 0;
   const pendingCommits = new Map<number, () => void>();
   const cancelledTimerIds: number[] = [];
-  let committedPreference = "system";
+  let committedPreference: ThemeMode = themeValues.system;
 
   const scheduleToggle = ((callback: () => void, delay?: number) => {
     assert.equal(delay, themeToggleDebounceMs);
@@ -241,35 +272,35 @@ test("queueThemeToggle debounces rapid theme toggles and only keeps the latest p
 
   assert.deepEqual(cancelledTimerIds, [1]);
   assert.deepEqual([...pendingCommits.keys()], [2]);
-  assert.equal(committedPreference, "system");
+  assert.equal(committedPreference, themeValues.system);
 
   pendingCommits.get(2)?.();
 
-  assert.equal(committedPreference, "light");
+  assert.equal(committedPreference, themeValues.light);
 });
 
 test("applyThemePreference sets dark mode attributes and color scheme explicitly", () => {
   const themeDocument = createThemeDocument();
 
-  const resolvedTheme = applyThemePreference(themeDocument, "dark");
+  const resolvedTheme = applyThemePreference(themeDocument, themeValues.dark);
 
-  assert.equal(resolvedTheme, "dark");
-  assert.equal(themeDocument.documentElement.dataset.theme, "dark");
-  assert.equal(themeDocument.documentElement.style.colorScheme, "dark");
+  assert.equal(resolvedTheme, themeValues.dark);
+  assert.equal(themeDocument.documentElement.dataset.theme, themeValues.dark);
+  assert.equal(themeDocument.documentElement.style.colorScheme, themeValues.dark);
 });
 
 test("applyThemePreference clears the dark attribute for light and system fallback", () => {
   const themeDocument = createThemeDocument();
-  themeDocument.documentElement.dataset.theme = "dark";
+  themeDocument.documentElement.dataset.theme = themeValues.dark;
 
-  const resolvedLightTheme = applyThemePreference(themeDocument, "light");
-  assert.equal(resolvedLightTheme, "light");
+  const resolvedLightTheme = applyThemePreference(themeDocument, themeValues.light);
+  assert.equal(resolvedLightTheme, themeValues.light);
   assert.equal(themeDocument.documentElement.dataset.theme, undefined);
-  assert.equal(themeDocument.documentElement.style.colorScheme, "light");
+  assert.equal(themeDocument.documentElement.style.colorScheme, themeValues.light);
 
-  themeDocument.documentElement.dataset.theme = "dark";
-  const resolvedSystemTheme = applyThemePreference(themeDocument, "system");
-  assert.equal(resolvedSystemTheme, "light");
+  themeDocument.documentElement.dataset.theme = themeValues.dark;
+  const resolvedSystemTheme = applyThemePreference(themeDocument, themeValues.system);
+  assert.equal(resolvedSystemTheme, themeValues.light);
   assert.equal(themeDocument.documentElement.dataset.theme, undefined);
-  assert.equal(themeDocument.documentElement.style.colorScheme, "light");
+  assert.equal(themeDocument.documentElement.style.colorScheme, themeValues.light);
 });


### PR DESCRIPTION
## Linked Issue

Closes #241

## Summary

- wire `prefers-color-scheme` detection into the existing theme provider so `system` actually follows the OS preference
- subscribe to OS theme changes with cleanup and keep manual `light` / `dark` preferences authoritative
- keep the implementation on the truthful live `apps/web/src/...` surface instead of fabricating the stale `packages/ui/...` paths from the issue body

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm exec tsx --test tests/unit/web-theme-token-contract.test.ts`
- [x] `pnpm exec tsx --test tests/unit/web-theme-provider.test.ts`
- [x] `pnpm test:unit`
- [x] `pnpm --filter @collabsphere/web run build`

## Risks / Notes

- supports both modern `addEventListener('change', ...)` and legacy `addListener(...)` media-query listeners with cleanup
- `#242` toggle UI is still deferred
- `#243` pre-paint theme initialization / FOUC prevention is still deferred
- bounded local rerun of `pnpm --filter @collabsphere/web run build` now completes successfully on this head; the earlier timeout note was a stale shell-local anomaly and no compile error surfaced

## Handoff

- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

## Handoff Summary

- add only live OS preference detection and listener cleanup to the existing provider contract

## Handoff Validation Evidence

- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec tsx --test tests/unit/web-theme-token-contract.test.ts`
- `pnpm exec tsx --test tests/unit/web-theme-provider.test.ts`
- `pnpm test:unit`
- `pnpm --filter @collabsphere/web run build`

## Handoff Open Issues / Follow-ups

- `#242` adds the user-facing theme toggle UI
- `#243` adds pre-paint theme initialization / FOUC prevention
- `#1174` remains the blocked story validation gate

## Handoff Risks / Deviations

- manual browser validation was substituted with focused matchMedia stubs in unit coverage because no interactive browser session was used in this pass

## Review Guidance

- Relevant docs: `docs/spec/03-information-architecture/03.9-theme-system.md`, `docs/spec/03-information-architecture/03.10-accessibility.md`, `apps/web/AGENTS.md`
- Areas that need extra scrutiny: matchMedia wiring, cleanup behavior, and preserving manual-theme authority when OS preference changes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rick1330/collabsphere/pull/1518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and responding to system theme preferences, allowing the app to automatically adapt to OS and browser dark mode settings.

* **Tests**
  * Expanded unit test coverage for theme system integration, including preference resolution, system theme detection, and preference change subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
