### PR TITLE
fix(web): resolve cs-011 validation review residue

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -394,6 +394,7 @@ button {
 .mobile-menu__panel {
   position: absolute;
   inset: 0 auto 0 0;
+  z-index: 13;
   width: min(24rem, 100vw);
   max-width: 100%;
   max-height: 100vh;
@@ -1568,7 +1569,7 @@ button {
   cursor: pointer;
 }
 
-.shell-user-menu__option:disabled {
+.shell-user-menu__option[aria-disabled="true"] {
   cursor: wait;
   opacity: 0.9;
 }
@@ -1584,13 +1585,15 @@ button {
 
 .shell-user-menu__option--signout {
   border-color:
-    color-mix(in srgb, #d97706 32%, var(--border-subtle));
+    color-mix(in srgb, var(--color-warning) 32%, var(--border-subtle));
 }
 
 .shell-user-menu__option--signout:hover,
 .shell-user-menu__option--signout:focus-visible {
-  border-color: color-mix(in srgb, #b45309 44%, var(--border-subtle));
-  background: color-mix(in srgb, #f59e0b 8%, var(--surface-card));
+  border-color:
+    color-mix(in srgb, var(--color-warning) 44%, var(--border-subtle));
+  background:
+    color-mix(in srgb, var(--color-warning) 8%, var(--surface-card));
 }
 
 .shell-user-menu__action-mark {
@@ -1638,6 +1641,12 @@ button {
     color-mix(in srgb, var(--section-accent, var(--color-accent)) 6%, var(--surface-card));
   color: var(--color-text-secondary);
   font-size: 0.88rem;
+}
+
+.shell-user-menu__status-meta {
+  margin: -0.2rem 0 0;
+  color: var(--color-text-tertiary);
+  font-size: 0.82rem;
 }
 
 .top-nav__user-slot .shell-user-menu__trigger {

--- a/apps/web/src/components/foundation/mobile-menu.tsx
+++ b/apps/web/src/components/foundation/mobile-menu.tsx
@@ -218,6 +218,7 @@ export function MobileMenu({
           className="mobile-menu__dialog"
           aria-labelledby={`${menuId}-title`}
           aria-describedby={`${menuId}-description`}
+          aria-modal="true"
           open
           onCancel={handleDialogCancel}
           onKeyDown={handleDialogKeyDown}

--- a/apps/web/src/components/foundation/user-theme-menu.tsx
+++ b/apps/web/src/components/foundation/user-theme-menu.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import * as React from "react";
 import {
@@ -11,7 +12,7 @@ import {
   type PointerEvent as ReactPointerEvent,
 } from "react";
 
-import { logoutCurrentSession } from "../../lib/api/auth";
+import { AuthApiError, logoutCurrentSession } from "../../lib/api/auth";
 import type { ThemePreference } from "../../lib/theme";
 import { useTheme } from "../theme/theme-provider";
 
@@ -62,6 +63,13 @@ type UserMenuSignOutAction = {
 
 type UserMenuAction = UserMenuLinkAction | UserMenuThemeAction | UserMenuSignOutAction;
 
+type ThemeUserMenuSignOutState =
+  | { kind: "pending"; message: string; requestId: null }
+  | { kind: "error"; message: string; requestId: string | null }
+  | null;
+
+type UserMenuItemElement = HTMLAnchorElement | HTMLButtonElement;
+
 const placeholderIdentity = {
   badge: "Shell",
   description:
@@ -70,6 +78,10 @@ const placeholderIdentity = {
   name: "CollabSphere member",
   triggerMeta: "Account shell with local theme controls",
 } as const;
+
+const navigationSectionLabel = "Account shortcuts";
+const themeSectionLabel = "Display theme";
+const signOutSectionLabel = "Session";
 
 export const themeMenuOptions: readonly ThemeMenuOption[] = [
   {
@@ -183,6 +195,42 @@ export const getThemeMenuStatusLabel = (
   return `${preference === "light" ? "Light" : "Dark"} locked`;
 };
 
+export const getThemeUserMenuSignOutState = ({
+  error,
+  isError,
+  isPending,
+}: {
+  error: unknown;
+  isError: boolean;
+  isPending: boolean;
+}): ThemeUserMenuSignOutState => {
+  if (isPending) {
+    return {
+      kind: "pending",
+      message: "Signing out of the current session.",
+      requestId: null,
+    };
+  }
+
+  if (!isError) {
+    return null;
+  }
+
+  if (error instanceof AuthApiError) {
+    return {
+      kind: "error",
+      message: error.message,
+      requestId: error.requestId,
+    };
+  }
+
+  return {
+    kind: "error",
+    message: "Unable to sign out. Please try again.",
+    requestId: null,
+  };
+};
+
 const getThemeActions = (): UserMenuThemeAction[] =>
   themeMenuOptions.map((option) => ({
     kind: "theme",
@@ -198,14 +246,6 @@ const getUserMenuActions = (): UserMenuAction[] => [
   signOutAction,
 ];
 
-const navigateToMenuHref = (href: string) => {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  window.location.assign(href);
-};
-
 const redirectToLogin = () => {
   if (typeof window === "undefined") {
     return;
@@ -219,10 +259,7 @@ export function ThemeUserMenu({ initialOpen = false }: ThemeUserMenuProps) {
   const { preference, resolvedTheme, setThemePreference } = useTheme();
   const menuId = useId();
   const triggerId = `${menuId}-trigger`;
-  const navigationLabelId = `${menuId}-navigation`;
-  const themeLabelId = `${menuId}-theme`;
-  const signOutLabelId = `${menuId}-signout`;
-  const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const itemRefs = useRef<Array<UserMenuItemElement | null>>([]);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const [hasMounted, setHasMounted] = useState(false);
@@ -233,9 +270,23 @@ export function ThemeUserMenu({ initialOpen = false }: ThemeUserMenuProps) {
     ? getThemeMenuStatusLabel(preference, resolvedTheme)
     : "Account menu";
 
+  const openMenu = (nextIndex = 0) => {
+    setActiveIndex(nextIndex);
+    setIsOpen(true);
+  };
+
+  const closeMenu = (restoreFocus = false) => {
+    setIsOpen(false);
+
+    if (restoreFocus) {
+      triggerRef.current?.focus();
+    }
+  };
+
   const signOutMutation = useMutation({
     mutationFn: () => logoutCurrentSession(),
     onSuccess: () => {
+      closeMenu();
       queryClient.clear();
       redirectToLogin();
     },
@@ -273,19 +324,6 @@ export function ThemeUserMenu({ initialOpen = false }: ThemeUserMenuProps) {
     };
   }, [isOpen]);
 
-  const openMenu = (nextIndex = 0) => {
-    setActiveIndex(nextIndex);
-    setIsOpen(true);
-  };
-
-  const closeMenu = (restoreFocus = false) => {
-    setIsOpen(false);
-
-    if (restoreFocus) {
-      triggerRef.current?.focus();
-    }
-  };
-
   const handleTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
     if (!isThemeMenuOpenKey(event.key)) {
       return;
@@ -316,7 +354,7 @@ export function ThemeUserMenu({ initialOpen = false }: ThemeUserMenuProps) {
   };
 
   const handleActionPointerMove = (
-    event: ReactPointerEvent<HTMLButtonElement>,
+    event: ReactPointerEvent<HTMLElement>,
     index: number,
   ) => {
     if (event.pointerType !== "mouse" && event.pointerType !== "pen") {
@@ -326,16 +364,14 @@ export function ThemeUserMenu({ initialOpen = false }: ThemeUserMenuProps) {
     setActiveIndex(index);
   };
 
-  const handleActionSelect = (action: UserMenuAction) => {
-    if (action.kind === "link") {
-      closeMenu();
-      navigateToMenuHref(action.href);
-      return;
-    }
-
+  const handleActionSelect = (action: UserMenuThemeAction | UserMenuSignOutAction) => {
     if (action.kind === "theme") {
       setThemePreference(action.preference);
       closeMenu(true);
+      return;
+    }
+
+    if (signOutMutation.isPending) {
       return;
     }
 
@@ -343,18 +379,11 @@ export function ThemeUserMenu({ initialOpen = false }: ThemeUserMenuProps) {
     signOutMutation.mutate();
   };
 
-  const signOutStatus =
-    signOutMutation.isPending
-      ? {
-          kind: "pending" as const,
-          message: "Signing out of the current session.",
-        }
-      : signOutMutation.isError
-        ? {
-            kind: "error" as const,
-            message: "Unable to sign out. Please try again.",
-          }
-        : null;
+  const signOutStatus = getThemeUserMenuSignOutState({
+    error: signOutMutation.error,
+    isError: signOutMutation.isError,
+    isPending: signOutMutation.isPending,
+  });
 
   return (
     <div ref={rootRef} className="shell-user-menu">
@@ -419,22 +448,22 @@ export function ThemeUserMenu({ initialOpen = false }: ThemeUserMenuProps) {
             aria-labelledby={triggerId}
             onKeyDown={handleMenuKeyDown}
           >
-            <p id={navigationLabelId} className="shell-user-menu__section-label">
-              Account shortcuts
+            <p className="shell-user-menu__section-label" role="presentation" aria-hidden="true">
+              {navigationSectionLabel}
             </p>
-            <div className="shell-user-menu__options" role="group" aria-labelledby={navigationLabelId}>
+            <div className="shell-user-menu__options" role="group" aria-label={navigationSectionLabel}>
               {navigationActions.map((action, index) => (
-                <button
+                <Link
                   key={action.key}
                   ref={(node) => {
                     itemRefs.current[index] = node;
                   }}
-                  type="button"
+                  href={action.href}
                   role="menuitem"
                   tabIndex={index === activeIndex ? 0 : -1}
                   className="shell-user-menu__option shell-user-menu__option--link"
                   onClick={() => {
-                    handleActionSelect(action);
+                    closeMenu();
                   }}
                   onFocus={() => {
                     setActiveIndex(index);
@@ -452,15 +481,15 @@ export function ThemeUserMenu({ initialOpen = false }: ThemeUserMenuProps) {
                       {action.description}
                     </span>
                   </span>
-                </button>
+                </Link>
               ))}
             </div>
 
             <div className="shell-user-menu__divider" role="presentation" />
-            <p id={themeLabelId} className="shell-user-menu__section-label">
-              Display theme
+            <p className="shell-user-menu__section-label" role="presentation" aria-hidden="true">
+              {themeSectionLabel}
             </p>
-            <div className="shell-user-menu__options" role="group" aria-labelledby={themeLabelId}>
+            <div className="shell-user-menu__options" role="group" aria-label={themeSectionLabel}>
               {themeMenuOptions.map((option, optionIndex) => {
                 const index = navigationActions.length + optionIndex;
                 const checked = option.value === preference;
@@ -510,10 +539,10 @@ export function ThemeUserMenu({ initialOpen = false }: ThemeUserMenuProps) {
             </div>
 
             <div className="shell-user-menu__divider" role="presentation" />
-            <p id={signOutLabelId} className="shell-user-menu__section-label">
-              Session
+            <p className="shell-user-menu__section-label" role="presentation" aria-hidden="true">
+              {signOutSectionLabel}
             </p>
-            <div className="shell-user-menu__options" role="group" aria-labelledby={signOutLabelId}>
+            <div className="shell-user-menu__options" role="group" aria-label={signOutSectionLabel}>
               <button
                 ref={(node) => {
                   itemRefs.current[actions.length - 1] = node;
@@ -532,7 +561,7 @@ export function ThemeUserMenu({ initialOpen = false }: ThemeUserMenuProps) {
                   handleActionPointerMove(event, actions.length - 1);
                 }}
                 aria-disabled={signOutMutation.isPending}
-                disabled={signOutMutation.isPending}
+                data-pending={signOutMutation.isPending || undefined}
               >
                 <span className="shell-user-menu__action-mark" aria-hidden="true">
                   {signOutAction.mark}
@@ -547,12 +576,19 @@ export function ThemeUserMenu({ initialOpen = false }: ThemeUserMenuProps) {
                 </span>
               </button>
               {signOutStatus ? (
-                <p
-                  className="shell-user-menu__status"
-                  role={signOutStatus.kind === "error" ? "alert" : "status"}
-                >
-                  {signOutStatus.message}
-                </p>
+                <>
+                  <p
+                    className="shell-user-menu__status"
+                    role={signOutStatus.kind === "error" ? "alert" : "status"}
+                  >
+                    {signOutStatus.message}
+                  </p>
+                  {signOutStatus.requestId ? (
+                    <p className="shell-user-menu__status-meta">
+                      Request ID: {signOutStatus.requestId}
+                    </p>
+                  ) : null}
+                </>
               ) : null}
             </div>
           </div>

--- a/tests/unit/web-mobile-menu.test.tsx
+++ b/tests/unit/web-mobile-menu.test.tsx
@@ -33,5 +33,6 @@ test("mobile menu renders the global navigation links when opened", () => {
   assert.match(markup, /Settings/);
   assert.match(markup, /Close navigation menu/);
   assert.match(markup, /<dialog/);
+  assert.match(markup, /aria-modal="true"/);
   assert.match(markup, /open=""/);
 });

--- a/tests/unit/web-theme-user-menu.test.tsx
+++ b/tests/unit/web-theme-user-menu.test.tsx
@@ -7,6 +7,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { AppProviders } from "../../apps/web/src/components/providers/app-providers";
 import { ShellFrame } from "../../apps/web/src/components/foundation/shell-frame";
 import {
+  getThemeUserMenuSignOutState,
   getThemeMenuOpenIndex,
   getThemeMenuNextIndex,
   getThemeMenuStatusLabel,
@@ -14,6 +15,7 @@ import {
   ThemeUserMenu,
   themeMenuOptions,
 } from "../../apps/web/src/components/foundation/user-theme-menu";
+import { AuthApiError } from "../../apps/web/src/lib/api/auth";
 import { globalNavItems } from "../../apps/web/src/components/foundation/navigation";
 
 test("theme user menu status label reflects system and manual preferences", () => {
@@ -44,6 +46,26 @@ test("theme user menu navigation-key guard narrows supported roving keys", () =>
   assert.equal(isThemeMenuNavigationKey("ArrowDown"), true);
   assert.equal(isThemeMenuNavigationKey("PageUp"), true);
   assert.equal(isThemeMenuNavigationKey("Tab"), false);
+});
+
+test("theme user menu sign-out state preserves request ids on API errors", () => {
+  const error = new AuthApiError("server", "Sign out could not be completed. Retry in a moment.", {
+    requestId: "req_123",
+    status: 503,
+  });
+
+  assert.deepEqual(
+    getThemeUserMenuSignOutState({
+      error,
+      isError: true,
+      isPending: false,
+    }),
+    {
+      kind: "error",
+      message: "Sign out could not be completed. Retry in a moment.",
+      requestId: "req_123",
+    },
+  );
 });
 
 test("theme user menu renders an accessible closed trigger inside the shell header", () => {
@@ -95,9 +117,15 @@ test("theme user menu renders account links, theme options, and sign-out action 
   assert.equal((markup.match(/role="menuitem"/g) ?? []).length, 3);
   assert.equal((markup.match(/role="menuitemradio"/g) ?? []).length, 3);
   assert.match(markup, /Account shortcuts/);
+  assert.match(markup, /role="presentation"/);
+  assert.match(markup, /aria-label="Account shortcuts"/);
   assert.match(markup, /Dashboard/);
+  assert.match(markup, /href="\/dashboard"/);
   assert.match(markup, /Settings/);
+  assert.match(markup, /href="\/settings\/profile"/);
+  assert.match(markup, /aria-label="Display theme"/);
   assert.match(markup, /Display theme/);
+  assert.match(markup, /aria-label="Session"/);
   assert.match(markup, /Session/);
   assert.match(markup, /Sign out/);
   assert.match(markup, /Profile, email, and role details will appear here/);


### PR DESCRIPTION
## Linked Issue

Refs #1175

## Summary

- fold still-valid merged-PR feedback from #1526 and #1527 into the CS-011 validation surface instead of leaving those defects stranded in closed review threads
- fix the account menu keyboard/a11y gaps by keeping sign-out focusable during pending state, restoring valid menu-group semantics, surfacing logout request IDs, and replacing raw sign-out colors with theme tokens
- fix the mobile menu modal contract by adding ria-modal="true", raising the panel above the overlay, and extending unit coverage for the repaired validation surface

## Validation

- [x] pnpm lint
- [x] pnpm typecheck
- [x] pnpm exec tsx --test tests/unit/web-theme-user-menu.test.tsx tests/unit/web-mobile-menu.test.tsx tests/unit/web-top-nav-bar.test.tsx
- [x] pnpm test:unit
- [x] pnpm --filter @collabsphere/web run build
- [x] pnpm review:coderabbit -- auth status
- [x] pnpm review:coderabbit -- review --type committed --base main

## Risks / Notes

- this PR addresses the still-valid current-main defects surfaced after merged PRs #1526 and #1527; it does not claim full CS-011 story validation completion yet
- full story-validation closure for #1175 still needs final acceptance/evidence reconciliation at the story level

## Handoff

- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

## Handoff Summary

- fixed real post-merge validation defects left behind on the merged account-menu and mobile-menu batons
- kept the remediation tightly scoped to the CS-011 validation surface on current main

## Handoff Validation Evidence

- pnpm lint
- pnpm typecheck
- pnpm exec tsx --test tests/unit/web-theme-user-menu.test.tsx tests/unit/web-mobile-menu.test.tsx tests/unit/web-top-nav-bar.test.tsx
- pnpm test:unit
- pnpm --filter @collabsphere/web run build
- pnpm review:coderabbit -- auth status
- pnpm review:coderabbit -- review --type committed --base main

## Handoff Open Issues / Follow-ups

- reconcile the remaining CS-011 story-validation checklist and acceptance evidence before closing #1175

## Handoff Risks / Deviations

- none beyond the still-open story-validation gate itself

## Review Guidance

- Relevant spec / agent-ref docs: docs/agent-ref/ui/accessibility.md, docs/agent-ref/ui/component-patterns.md, docs/agent-ref/ui/responsive-rules.md
- Areas that need extra scrutiny: account-menu roving tabindex behavior while sign-out is pending, and mobile dialog stacking/modal semantics
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rick1330/collabsphere/pull/1528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
