### PR TITLE
fix(web): finalize cs-012 shell review remediation

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -64,9 +64,19 @@ button {
   min-height: 100vh;
 }
 
+.shell--no-rail {
+  grid-template-columns: 1fr;
+}
+
 .shell__rail,
 .shell__content {
   padding: 1.5rem;
+}
+
+.shell__rail--default {
+  display: grid;
+  gap: 1.5rem;
+  align-content: start;
 }
 
 .shell__rail {

--- a/apps/web/src/components/foundation/shell-frame.tsx
+++ b/apps/web/src/components/foundation/shell-frame.tsx
@@ -28,12 +28,19 @@ export function ShellFrame({
   topNav,
   children,
 }: ShellFrameProps) {
+  const isRailOmitted = sidebar === null;
   const contentClassName =
     topNav == null ? "shell__content" : "shell__content shell__content--with-top-nav";
-  const shellClassName =
-    topNav == null ? `shell shell--${tone}` : `shell shell--${tone} shell--has-top-nav`;
+  const shellClassName = [
+    "shell",
+    `shell--${tone}`,
+    topNav == null ? null : "shell--has-top-nav",
+    isRailOmitted ? "shell--no-rail" : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
   const rail = (
-    <aside className="shell__rail" aria-label={`${sectionLabel} navigation`}>
+    <aside className="shell__rail shell__rail--default" aria-label={`${sectionLabel} navigation`}>
       <p className="shell__eyebrow">{sectionLabel}</p>
       <h1 className="shell__title">{title}</h1>
       <p className="shell__description">{description}</p>

--- a/tests/unit/web-global-sidebar.test.tsx
+++ b/tests/unit/web-global-sidebar.test.tsx
@@ -84,5 +84,29 @@ test("shell frame honors an explicit null sidebar instead of falling back to the
   );
 
   assert.doesNotMatch(markup, /class="shell__rail"/);
+  assert.match(markup, /class="shell shell--global shell--no-rail"/);
   assert.doesNotMatch(markup, /Authenticated global context navigation/);
+});
+
+test("shell frame keeps the structured default rail layout when no custom sidebar is supplied", () => {
+  const markup = renderToStaticMarkup(
+    <ShellFrame
+      tone="public"
+      sectionLabel="Public context"
+      title="CollabSphere"
+      description="Public shell"
+      navItems={[
+        {
+          href: "/",
+          hint: "Landing route",
+          label: "Landing",
+        },
+      ]}
+    >
+      <div>Public content</div>
+    </ShellFrame>,
+  );
+
+  assert.match(markup, /class="shell__rail shell__rail--default"/);
+  assert.doesNotMatch(markup, /shell--no-rail/);
 });

--- a/tests/unit/web-theme-token-contract.test.ts
+++ b/tests/unit/web-theme-token-contract.test.ts
@@ -79,16 +79,21 @@ test("globals.css imports the canonical theme/token styles and removes the old a
 
 test("globals.css keeps grid sidebar layout scoped to the concrete sidebar variants", () => {
   const shellRailRule = globalsCss.match(/\.shell__rail\s*\{([\s\S]*?)\}/)?.[1];
+  const defaultRailRule = globalsCss.match(/\.shell__rail--default\s*\{([\s\S]*?)\}/)?.[1];
   const globalSidebarRule = globalsCss.match(/\.global-sidebar\s*\{([\s\S]*?)\}/)?.[1];
   const workspaceSidebarRule = globalsCss.match(/\.workspace-sidebar\s*\{([\s\S]*?)\}/)?.[1];
 
   assert.ok(shellRailRule, "expected .shell__rail rule to exist");
+  assert.ok(defaultRailRule, "expected .shell__rail--default rule to exist");
   assert.ok(globalSidebarRule, "expected .global-sidebar rule to exist");
   assert.ok(workspaceSidebarRule, "expected .workspace-sidebar rule to exist");
 
   assert.doesNotMatch(shellRailRule, /display:\s*grid/);
   assert.doesNotMatch(shellRailRule, /gap:\s*1\.5rem/);
   assert.doesNotMatch(shellRailRule, /align-content:\s*start/);
+  assert.match(defaultRailRule, /display:\s*grid/);
+  assert.match(defaultRailRule, /gap:\s*1\.5rem/);
+  assert.match(defaultRailRule, /align-content:\s*start/);
   assert.match(globalSidebarRule, /display:\s*grid/);
   assert.match(globalSidebarRule, /align-content:\s*start/);
   assert.match(workspaceSidebarRule, /display:\s*grid/);


### PR DESCRIPTION
## Linked Issue

Closes #1531

## Summary

- restore the structured default rail layout for public/admin shell-frame usage
- switch the shell to a single-column layout when `sidebar={null}` intentionally omits the rail
- keep the earlier CS-012 merged-review remediation intact while closing the two current-head regressions raised on PR #1532

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm exec tsx --test tests/unit/web-global-sidebar.test.tsx tests/unit/web-theme-token-contract.test.ts tests/unit/web-top-nav-bar.test.tsx`
- [x] `pnpm test:unit`
- [x] `pnpm --filter @collabsphere/web run build`
- [x] `pnpm review:coderabbit -- auth status`
- [x] `pnpm review:coderabbit -- review --type committed --base main`

## Risks / Notes

- This PR supersedes the two unresolved current-head comments that remained on merged PR #1532.
- Parent story validation issue `#1176` still remains open after this remediation issue closes.

## Handoff

- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

## Handoff Summary

- final CS-012 current-main remediation for default-rail and no-rail shell layout behavior

## Handoff Validation Evidence

- lint, typecheck, focused shell/css tests, full unit suite, and web build all passed locally
- local CodeRabbit committed-diff review completed with no findings

## Handoff Open Issues / Follow-ups

- after merge, resolve the two stale unresolved threads on merged PR #1532
- `#1176` remains open for broader CS-012 validation scope

## Handoff Risks / Deviations

- none

## Review Guidance

- Relevant spec / agent-ref docs:
  - `apps/web/AGENTS.md`
  - `docs/agent-ref/ui/accessibility.md`
- Areas that need extra scrutiny:
  - default rail spacing on public/admin shells
  - full-width content behavior when `sidebar={null}`

## Local CodeRabbit CLI Review Outcome

- `pnpm review:coderabbit -- auth status` succeeded earlier in this session
- `pnpm review:coderabbit -- review --type committed --base main` completed with no findings on this follow-up diff
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rick1330/collabsphere/pull/1533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
