### PR TITLE
fix(web): ignore touchcancel for swipe actions

### DIFF
--- a/apps/web/src/components/foundation/use-mobile-sidebar-swipe.ts
+++ b/apps/web/src/components/foundation/use-mobile-sidebar-swipe.ts
@@ -101,15 +101,19 @@ export function useMobileSidebarSwipe({
       }
     };
 
+    const handleTouchCancel = () => {
+      documentTouchSessionRef.current = null;
+    };
+
     document.addEventListener("touchstart", handleTouchStart, { passive: true });
     document.addEventListener("touchend", handleTouchEnd, { passive: true });
-    document.addEventListener("touchcancel", handleTouchEnd, { passive: true });
+    document.addEventListener("touchcancel", handleTouchCancel, { passive: true });
 
     return () => {
       documentTouchSessionRef.current = null;
       document.removeEventListener("touchstart", handleTouchStart);
       document.removeEventListener("touchend", handleTouchEnd);
-      document.removeEventListener("touchcancel", handleTouchEnd);
+      document.removeEventListener("touchcancel", handleTouchCancel);
     };
   }, [enabled, isOpen, onOpen]);
 
@@ -177,15 +181,19 @@ export function useMobileSidebarSwipe({
       }
     };
 
+    const handleTouchCancel = () => {
+      panelTouchSessionRef.current = null;
+    };
+
     panel.addEventListener("touchstart", handleTouchStart, { passive: true });
     panel.addEventListener("touchend", handleTouchEnd, { passive: true });
-    panel.addEventListener("touchcancel", handleTouchEnd, { passive: true });
+    panel.addEventListener("touchcancel", handleTouchCancel, { passive: true });
 
     return () => {
       panelTouchSessionRef.current = null;
       panel.removeEventListener("touchstart", handleTouchStart);
       panel.removeEventListener("touchend", handleTouchEnd);
-      panel.removeEventListener("touchcancel", handleTouchEnd);
+      panel.removeEventListener("touchcancel", handleTouchCancel);
     };
   }, [enabled, isOpen, onClose, panelRef]);
 }

--- a/apps/web/src/components/foundation/use-mobile-sidebar-swipe.ts
+++ b/apps/web/src/components/foundation/use-mobile-sidebar-swipe.ts
@@ -77,6 +77,10 @@ export function useMobileSidebarSwipe({
         return;
       }
 
+      if (event.type === "touchcancel") {
+        return;
+      }
+
       const coordinates = readTouchCoordinates(event.changedTouches);
       if (coordinates.x == null) {
         return;
@@ -101,19 +105,15 @@ export function useMobileSidebarSwipe({
       }
     };
 
-    const handleTouchCancel = () => {
-      documentTouchSessionRef.current = null;
-    };
-
     document.addEventListener("touchstart", handleTouchStart, { passive: true });
     document.addEventListener("touchend", handleTouchEnd, { passive: true });
-    document.addEventListener("touchcancel", handleTouchCancel, { passive: true });
+    document.addEventListener("touchcancel", handleTouchEnd, { passive: true });
 
     return () => {
       documentTouchSessionRef.current = null;
       document.removeEventListener("touchstart", handleTouchStart);
       document.removeEventListener("touchend", handleTouchEnd);
-      document.removeEventListener("touchcancel", handleTouchCancel);
+      document.removeEventListener("touchcancel", handleTouchEnd);
     };
   }, [enabled, isOpen, onOpen]);
 
@@ -157,6 +157,10 @@ export function useMobileSidebarSwipe({
         return;
       }
 
+      if (event.type === "touchcancel") {
+        return;
+      }
+
       const coordinates = readTouchCoordinates(event.changedTouches);
       if (coordinates.x == null) {
         return;
@@ -181,19 +185,15 @@ export function useMobileSidebarSwipe({
       }
     };
 
-    const handleTouchCancel = () => {
-      panelTouchSessionRef.current = null;
-    };
-
     panel.addEventListener("touchstart", handleTouchStart, { passive: true });
     panel.addEventListener("touchend", handleTouchEnd, { passive: true });
-    panel.addEventListener("touchcancel", handleTouchCancel, { passive: true });
+    panel.addEventListener("touchcancel", handleTouchEnd, { passive: true });
 
     return () => {
       panelTouchSessionRef.current = null;
       panel.removeEventListener("touchstart", handleTouchStart);
       panel.removeEventListener("touchend", handleTouchEnd);
-      panel.removeEventListener("touchcancel", handleTouchCancel);
+      panel.removeEventListener("touchcancel", handleTouchEnd);
     };
   }, [enabled, isOpen, onClose, panelRef]);
 }


### PR DESCRIPTION
## Linked Issue

Refs #253

## Summary

- treat `touchcancel` as cleanup-only so cancelled touches cannot trigger sidebar swipe open/close

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm exec tsx --test tests/unit/web-mobile-menu.test.tsx`

## Risks / Notes

- none

## Handoff

- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

## Handoff Summary

- prevent unintended mobile sidebar open/close when a touch gesture is cancelled by the system/browser

## Handoff Validation Evidence

- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec tsx --test tests/unit/web-mobile-menu.test.tsx`

## Handoff Open Issues / Follow-ups

- none

## Handoff Risks / Deviations

- none

## Review Guidance

- Relevant spec / agent-ref docs: `docs/spec/03-information-architecture/03.8-responsive-specs.md`, `docs/agent-ref/ui/responsive-rules.md`, `docs/agent-ref/ui/accessibility.md`
- Areas that need extra scrutiny: `apps/web/src/components/foundation/use-mobile-sidebar-swipe.ts`

