### PR TITLE
fix(web): address Devin/Copilot review for command palette shortcut

### DIFF
--- a/apps/web/src/components/foundation/command-palette.tsx
+++ b/apps/web/src/components/foundation/command-palette.tsx
@@ -20,6 +20,7 @@ export type CommandPaletteGroup = {
 
 type CommandPaletteProps = {
   groups: readonly CommandPaletteGroup[];
+  dialogId?: string;
   isOpen: boolean;
   onClose: () => void;
   query: string;
@@ -173,6 +174,7 @@ function CommandPaletteFooter() {
 }
 
 export function CommandPalette({
+  dialogId,
   groups,
   inputRef,
   isOpen,
@@ -303,6 +305,7 @@ export function CommandPalette({
   return isOpen ? (
     <dialog
       ref={dialogRef}
+      id={dialogId}
       className="command-palette__dialog"
       aria-modal="true"
       aria-labelledby={titleId}

--- a/apps/web/src/components/foundation/top-nav-command-palette.tsx
+++ b/apps/web/src/components/foundation/top-nav-command-palette.tsx
@@ -94,7 +94,7 @@ export function TopNavCommandPalette({
           ref={triggerRef}
           type="button"
           className="top-nav__search-trigger"
-          aria-controls={dialogId}
+          aria-controls={isOpen ? dialogId : undefined}
           aria-expanded={isOpen}
           aria-haspopup="dialog"
           aria-label="Open command palette"

--- a/apps/web/src/components/foundation/top-nav-command-palette.tsx
+++ b/apps/web/src/components/foundation/top-nav-command-palette.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 
 import { CommandPalette, type CommandPaletteGroup } from "./command-palette";
+import { isMacLikePlatform } from "./command-palette-shortcut";
 import { useCommandPaletteShortcut } from "./use-command-palette-shortcut";
 
 const commandPaletteGroups: readonly CommandPaletteGroup[] = [
@@ -49,8 +50,23 @@ export function TopNavCommandPalette({
 }: Readonly<TopNavCommandPaletteProps>) {
   const [isOpen, setIsOpen] = React.useState(initialOpen);
   const [query, setQuery] = React.useState("");
+  const [modifierLabel, setModifierLabel] = React.useState<"Ctrl" | "Cmd">("Ctrl");
   const triggerRef = React.useRef<HTMLButtonElement | null>(null);
   const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const dialogId = `command-palette-${React.useId()}`;
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const isMacLike = isMacLikePlatform({
+      platform: window.navigator.platform,
+      userAgent: window.navigator.userAgent,
+    });
+
+    setModifierLabel(isMacLike ? "Cmd" : "Ctrl");
+  }, []);
 
   const openPalette = React.useCallback(() => {
     setIsOpen(true);
@@ -78,6 +94,9 @@ export function TopNavCommandPalette({
           ref={triggerRef}
           type="button"
           className="top-nav__search-trigger"
+          aria-controls={dialogId}
+          aria-expanded={isOpen}
+          aria-haspopup="dialog"
           aria-label="Open command palette"
           onClick={openPalette}
         >
@@ -91,12 +110,13 @@ export function TopNavCommandPalette({
             </span>
           </span>
           <span className="top-nav__shortcut" aria-hidden="true">
-            <kbd>Ctrl</kbd>
+            <kbd>{modifierLabel}</kbd>
             <kbd>K</kbd>
           </span>
         </button>
       </div>
       <CommandPalette
+        dialogId={dialogId}
         groups={commandPaletteGroups}
         inputRef={inputRef}
         isOpen={isOpen}

--- a/tests/unit/web-top-nav-bar.test.tsx
+++ b/tests/unit/web-top-nav-bar.test.tsx
@@ -77,7 +77,6 @@ test("top nav renders authenticated shell regions with a live workspace switcher
   assert.match(markup, /top-nav__search top-nav__search--desktop-only/);
   assert.match(markup, /aria-haspopup="dialog"/);
   assert.match(markup, /aria-expanded="false"/);
-  assert.match(markup, /aria-controls="command-palette-/);
   assert.match(markup, /Notifications/);
   assert.match(markup, /12 unread in your recent feed/);
   assert.match(markup, /Open navigation menu/);
@@ -111,6 +110,8 @@ test("top nav can render an initially open command palette in the authenticated 
     </AppProviders>,
   );
 
+  assert.match(markup, /aria-expanded="true"/);
+  assert.match(markup, /aria-controls="command-palette-/);
   assert.match(markup, /<dialog/);
   assert.match(markup, /Command palette/);
   assert.match(markup, /Search commands/);

--- a/tests/unit/web-top-nav-bar.test.tsx
+++ b/tests/unit/web-top-nav-bar.test.tsx
@@ -75,6 +75,9 @@ test("top nav renders authenticated shell regions with a live workspace switcher
   assert.match(markup, /Current workspace · Tech Lead/);
   assert.match(markup, /Open command palette/);
   assert.match(markup, /top-nav__search top-nav__search--desktop-only/);
+  assert.match(markup, /aria-haspopup="dialog"/);
+  assert.match(markup, /aria-expanded="false"/);
+  assert.match(markup, /aria-controls="command-palette-/);
   assert.match(markup, /Notifications/);
   assert.match(markup, /12 unread in your recent feed/);
   assert.match(markup, /Open navigation menu/);


### PR DESCRIPTION
## Linked Issue

Refs #255

Follow-up to PR `#1544` (merged) addressing review feedback from Devin and Copilot.

## Summary

- fix command palette trigger semantics: add `aria-haspopup="dialog"`, `aria-expanded`, and `aria-controls` wired to a stable dialog `id`
- fix shortcut hint so macOS users see `Cmd+K` (computed post-hydration to avoid SSR/hydration mismatch)

## Validation

- [x] `pnpm -w lint`
- [x] `pnpm typecheck`
- [x] `pnpm exec tsx --test tests/unit/web-command-palette-shortcut.test.ts`
- [x] `pnpm exec tsx --test tests/unit/web-command-palette.test.tsx`
- [x] `pnpm exec tsx --test tests/unit/web-top-nav-bar.test.tsx`
- [x] `pnpm test:unit` (note: first run flaked in `api-bootstrap-env` but rerun passed with no code changes)
- [x] `pnpm --filter @collabsphere/web run build`

## Local CodeRabbit CLI review outcome

- `pnpm review:coderabbit -- review --type committed --base main`: `No findings`

## Risks / Notes

- none

## Handoff

- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

## Handoff Summary

- follow-up fixes for the already-delivered `Cmd/Ctrl+K` command palette shortcut:
- macOS hint renders `Cmd+K` after hydration
- trigger now exposes dialog relationship via `aria-haspopup="dialog"`, `aria-expanded`, and `aria-controls`

## Handoff Validation Evidence

- `pnpm -w lint`
- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm --filter @collabsphere/web run build`

## Handoff Open Issues / Follow-ups

- none

## Handoff Risks / Deviations

- none

## Review Guidance

- Relevant spec / agent-ref docs: `docs/spec/03-information-architecture/03.10-accessibility.md`
- Areas that need extra scrutiny: ARIA trigger wiring (`aria-controls` id stability) and avoiding hydration mismatch for the modifier label
