### PR TITLE
feat(web): command palette result icons and workspace pill

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1066,8 +1066,9 @@ button {
   width: 100%;
   min-height: 2.85rem;
   display: grid;
-  gap: 0.12rem;
-  align-content: start;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  column-gap: 0.75rem;
+  align-items: center;
   padding: 0.75rem 0.8rem;
   text-align: left;
   border-radius: 1.15rem;
@@ -1076,6 +1077,41 @@ button {
   box-shadow: var(--shadow-soft);
   color: inherit;
   cursor: pointer;
+}
+
+.command-palette__item-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 2.35rem;
+  height: 2.35rem;
+  border-radius: 0.95rem;
+  font-size: 1.08rem;
+  line-height: 1;
+  background:
+    color-mix(in srgb, var(--section-accent, var(--color-accent)) 12%, var(--surface-card));
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 14%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--color-border) 55%, transparent);
+}
+
+.command-palette__item-copy {
+  display: grid;
+  gap: 0.12rem;
+  min-width: 0;
+}
+
+.command-palette__item-pill {
+  justify-self: end;
+  align-self: start;
+  margin-top: 0.15rem;
+  padding: 0.18rem 0.48rem;
+  border-radius: 999px;
+  background:
+    color-mix(in srgb, var(--section-accent, var(--color-accent)) 16%, var(--surface-card));
+  color: var(--color-text-secondary);
+  font-size: 0.74rem;
+  font-weight: 700;
+  white-space: nowrap;
 }
 
 .command-palette__item-button:hover,

--- a/apps/web/src/components/foundation/command-palette-search-helpers.ts
+++ b/apps/web/src/components/foundation/command-palette-search-helpers.ts
@@ -23,11 +23,19 @@ export const getSearchScopeFromPathname = (
 export const stripSearchSnippetMarkup = (value: string) =>
   value.replaceAll(/<\/?mark>/g, "");
 
-const buildDisabledItem = (id: string, label: string, description?: string): CommandPaletteItem => ({
+const getWorkspaceScopePill = (scope?: SearchScope) => (scope === "workspace" ? "Workspace" : undefined);
+
+const buildDisabledItem = (
+  id: string,
+  label: string,
+  description?: string,
+  options?: { icon?: CommandPaletteItem["icon"]; pill?: string },
+): CommandPaletteItem => ({
   id,
-  icon: "…",
+  icon: options?.icon ?? "…",
   label,
   description,
+  pill: options?.pill,
   disabled: true,
 });
 
@@ -42,7 +50,7 @@ export const buildCommandPaletteSearchGroups = ({
 }>) => {
   const documents = search.documents.slice(0, 5);
   const tasks = search.tasks.slice(0, 5);
-  const pill = scope === "workspace" ? "Workspace" : undefined;
+  const pill = getWorkspaceScopePill(scope);
 
   const groups: CommandPaletteGroup[] = [];
 
@@ -88,9 +96,66 @@ export const buildCommandPaletteSearchGroups = ({
     {
       id: "search-empty",
       label: "Search",
-      items: [{ ...buildDisabledItem("search-empty", "No results found."), icon: "🔎" }],
+      items: [buildDisabledItem("search-empty", "No results found.", undefined, { icon: "🔎" })],
     },
   ];
+};
+
+const buildCommandPaletteSearchStatusGroups = ({
+  onSelectUrl,
+  scope,
+  status,
+}: Readonly<{
+  status: CommandPaletteSearchStatus;
+  onSelectUrl: (url: string) => void;
+  scope?: SearchScope;
+}>) => {
+  const pill = getWorkspaceScopePill(scope);
+
+  if (status.kind === "loading") {
+    return [
+      {
+        id: "search-documents-loading",
+        label: "Documents",
+        items: [
+          buildDisabledItem("search-documents-loading", "Searching documents...", undefined, {
+            icon: "⏳",
+            pill,
+          }),
+        ],
+      },
+      {
+        id: "search-tasks-loading",
+        label: "Tasks",
+        items: [
+          buildDisabledItem("search-tasks-loading", "Searching tasks...", undefined, { icon: "⏳", pill }),
+        ],
+      },
+    ] satisfies CommandPaletteGroup[];
+  }
+
+  if (status.kind === "error") {
+    return [
+      {
+        id: "search-error",
+        label: "Search",
+        items: [
+          buildDisabledItem(
+            "search-error",
+            status.message,
+            status.requestId ? `Request id: ${status.requestId}` : undefined,
+            { icon: "⚠️" },
+          ),
+        ],
+      },
+    ] satisfies CommandPaletteGroup[];
+  }
+
+  if (status.kind === "loaded") {
+    return buildCommandPaletteSearchGroups({ search: status.results, onSelectUrl, scope });
+  }
+
+  return [];
 };
 
 export const buildCommandPaletteGroups = ({
@@ -110,63 +175,10 @@ export const buildCommandPaletteGroups = ({
     return [...baseGroups];
   }
 
-  if (status.kind === "loading") {
-    const pill = scope === "workspace" ? "Workspace" : undefined;
-    return [
-      ...baseGroups,
-      {
-        id: "search-documents-loading",
-        label: "Documents",
-        items: [
-          {
-            ...buildDisabledItem("search-documents-loading", "Searching documents..."),
-            icon: "⏳",
-            pill,
-          },
-        ],
-      },
-      {
-        id: "search-tasks-loading",
-        label: "Tasks",
-        items: [
-          {
-            ...buildDisabledItem("search-tasks-loading", "Searching tasks..."),
-            icon: "⏳",
-            pill,
-          },
-        ],
-      },
-    ];
-  }
-
-  if (status.kind === "error") {
-    return [
-      ...baseGroups,
-      {
-        id: "search-error",
-        label: "Search",
-        items: [
-          {
-            ...buildDisabledItem(
-              "search-error",
-              status.message,
-              status.requestId ? `Request id: ${status.requestId}` : undefined,
-            ),
-            icon: "⚠️",
-          },
-        ],
-      },
-    ];
-  }
-
-  if (status.kind === "loaded") {
-    return [
-      ...baseGroups,
-      ...buildCommandPaletteSearchGroups({ search: status.results, onSelectUrl, scope }),
-    ];
-  }
-
-  return [...baseGroups];
+  return [
+    ...baseGroups,
+    ...buildCommandPaletteSearchStatusGroups({ status, onSelectUrl, scope }),
+  ];
 };
 
 export const toSearchStatusFromResponse = (response: SearchResponse): CommandPaletteSearchStatus => ({

--- a/apps/web/src/components/foundation/command-palette-search-helpers.ts
+++ b/apps/web/src/components/foundation/command-palette-search-helpers.ts
@@ -25,6 +25,7 @@ export const stripSearchSnippetMarkup = (value: string) =>
 
 const buildDisabledItem = (id: string, label: string, description?: string): CommandPaletteItem => ({
   id,
+  icon: "…",
   label,
   description,
   disabled: true,
@@ -33,12 +34,15 @@ const buildDisabledItem = (id: string, label: string, description?: string): Com
 export const buildCommandPaletteSearchGroups = ({
   onSelectUrl,
   search,
+  scope,
 }: Readonly<{
   search: SearchResults;
   onSelectUrl: (url: string) => void;
+  scope?: SearchScope;
 }>) => {
   const documents = search.documents.slice(0, 5);
   const tasks = search.tasks.slice(0, 5);
+  const pill = scope === "workspace" ? "Workspace" : undefined;
 
   const groups: CommandPaletteGroup[] = [];
 
@@ -48,8 +52,10 @@ export const buildCommandPaletteSearchGroups = ({
       label: "Documents",
       items: documents.map((result) => ({
         id: `doc-${result.id}`,
+        icon: "📄",
         label: result.title,
         description: stripSearchSnippetMarkup(result.snippet),
+        pill,
         onSelect: () => {
           onSelectUrl(result.url);
         },
@@ -63,8 +69,10 @@ export const buildCommandPaletteSearchGroups = ({
       label: "Tasks",
       items: tasks.map((result) => ({
         id: `task-${result.id}`,
+        icon: "✅",
         label: result.title,
         description: stripSearchSnippetMarkup(result.snippet),
+        pill,
         onSelect: () => {
           onSelectUrl(result.url);
         },
@@ -80,7 +88,7 @@ export const buildCommandPaletteSearchGroups = ({
     {
       id: "search-empty",
       label: "Search",
-      items: [buildDisabledItem("search-empty", "No results found.")],
+      items: [{ ...buildDisabledItem("search-empty", "No results found."), icon: "🔎" }],
     },
   ];
 };
@@ -89,29 +97,44 @@ export const buildCommandPaletteGroups = ({
   baseGroups,
   normalizedQuery,
   onSelectUrl,
+  scope,
   status,
 }: Readonly<{
   baseGroups: readonly CommandPaletteGroup[];
   normalizedQuery: string;
   status: CommandPaletteSearchStatus;
   onSelectUrl: (url: string) => void;
+  scope?: SearchScope;
 }>) => {
   if (normalizedQuery.length < 2) {
     return [...baseGroups];
   }
 
   if (status.kind === "loading") {
+    const pill = scope === "workspace" ? "Workspace" : undefined;
     return [
       ...baseGroups,
       {
         id: "search-documents-loading",
         label: "Documents",
-        items: [buildDisabledItem("search-documents-loading", "Searching documents...")],
+        items: [
+          {
+            ...buildDisabledItem("search-documents-loading", "Searching documents..."),
+            icon: "⏳",
+            pill,
+          },
+        ],
       },
       {
         id: "search-tasks-loading",
         label: "Tasks",
-        items: [buildDisabledItem("search-tasks-loading", "Searching tasks...")],
+        items: [
+          {
+            ...buildDisabledItem("search-tasks-loading", "Searching tasks..."),
+            icon: "⏳",
+            pill,
+          },
+        ],
       },
     ];
   }
@@ -123,11 +146,14 @@ export const buildCommandPaletteGroups = ({
         id: "search-error",
         label: "Search",
         items: [
-          buildDisabledItem(
-            "search-error",
-            status.message,
-            status.requestId ? `Request id: ${status.requestId}` : undefined,
-          ),
+          {
+            ...buildDisabledItem(
+              "search-error",
+              status.message,
+              status.requestId ? `Request id: ${status.requestId}` : undefined,
+            ),
+            icon: "⚠️",
+          },
         ],
       },
     ];
@@ -136,7 +162,7 @@ export const buildCommandPaletteGroups = ({
   if (status.kind === "loaded") {
     return [
       ...baseGroups,
-      ...buildCommandPaletteSearchGroups({ search: status.results, onSelectUrl }),
+      ...buildCommandPaletteSearchGroups({ search: status.results, onSelectUrl, scope }),
     ];
   }
 

--- a/apps/web/src/components/foundation/command-palette.tsx
+++ b/apps/web/src/components/foundation/command-palette.tsx
@@ -7,8 +7,10 @@ import { getFocusableElements, getFocusTrapTarget } from "./dialog-focus-trap";
 
 export type CommandPaletteItem = {
   id: string;
+  icon?: React.ReactNode;
   label: string;
   description?: string;
+  pill?: string;
   onSelect?: () => void | Promise<void>;
   disabled?: boolean;
 };
@@ -129,10 +131,20 @@ function CommandPaletteResultItem({ item, onSelect }: Readonly<CommandPaletteRes
       disabled={item.disabled}
       onClick={onSelect}
     >
-      <span className="command-palette__item-label">{item.label}</span>
-      {item.description ? (
-        <span id={descriptionId} className="command-palette__item-description">
-          {item.description}
+      <span className="command-palette__item-icon" aria-hidden="true">
+        {item.icon ?? "•"}
+      </span>
+      <span className="command-palette__item-copy">
+        <span className="command-palette__item-label">{item.label}</span>
+        {item.description ? (
+          <span id={descriptionId} className="command-palette__item-description">
+            {item.description}
+          </span>
+        ) : null}
+      </span>
+      {item.pill ? (
+        <span className="command-palette__item-pill" aria-hidden="true">
+          {item.pill}
         </span>
       ) : null}
     </button>

--- a/apps/web/src/components/foundation/top-nav-command-palette.tsx
+++ b/apps/web/src/components/foundation/top-nav-command-palette.tsx
@@ -19,11 +19,13 @@ const commandPaletteGroups: readonly CommandPaletteGroup[] = [
     items: [
       {
         id: "recent-dashboard",
+        icon: "🏠",
         label: "Dashboard",
         description: "Quick return to the global overview",
       },
       {
         id: "recent-workspaces",
+        icon: "🗂️",
         label: "Workspaces",
         description: "Recent and starred collaboration spaces",
       },
@@ -35,11 +37,13 @@ const commandPaletteGroups: readonly CommandPaletteGroup[] = [
     items: [
       {
         id: "action-new-workspace",
+        icon: "➕",
         label: "Create new workspace",
         description: "Start a new shared project space",
       },
       {
         id: "action-settings",
+        icon: "⚙️",
         label: "Go to settings",
         description: "Manage profile and app preferences",
       },
@@ -134,9 +138,10 @@ export function TopNavCommandPalette({
         baseGroups: commandPaletteGroups,
         normalizedQuery,
         onSelectUrl,
+        scope: searchScope.scope,
         status: searchStatus,
       }),
-    [normalizedQuery, onSelectUrl, searchStatus],
+    [normalizedQuery, onSelectUrl, searchScope.scope, searchStatus],
   );
 
   return (

--- a/tests/unit/web-command-palette-search.test.ts
+++ b/tests/unit/web-command-palette-search.test.ts
@@ -9,6 +9,33 @@ import {
   stripSearchSnippetMarkup,
 } from "../../apps/web/src/components/foundation/command-palette-search-helpers";
 
+const workspaceScopedLoadedStatus = {
+  kind: "loaded" as const,
+  query: "lo",
+  results: {
+    documents: [
+      {
+        id: "doc-1",
+        title: "Doc 1",
+        snippet: "a hit",
+        updatedAt: "2025-07-17T12:10:00Z",
+        url: "/w/workspace-alpha/documents/doc-1",
+      },
+    ],
+    tasks: [
+      {
+        id: "task-1",
+        title: "Task 1",
+        snippet: "b hit",
+        status: "open",
+        priority: "low",
+        dueDate: null,
+        url: "/w/workspace-alpha/tasks/task-1",
+      },
+    ],
+  },
+};
+
 test("normalizeSearchQuery trims and caps at 200 chars", () => {
   assert.equal(normalizeSearchQuery("  hi  "), "hi");
   assert.equal(normalizeSearchQuery("a".repeat(250)).length, 200);
@@ -111,32 +138,7 @@ test("buildCommandPaletteGroups annotates search results with icons and workspac
     baseGroups: [],
     normalizedQuery: "lo",
     scope: "workspace",
-    status: {
-      kind: "loaded",
-      query: "lo",
-      results: {
-        documents: [
-          {
-            id: "doc-1",
-            title: "Doc 1",
-            snippet: "a hit",
-            updatedAt: "2025-07-17T12:10:00Z",
-            url: "/w/workspace-alpha/documents/doc-1",
-          },
-        ],
-        tasks: [
-          {
-            id: "task-1",
-            title: "Task 1",
-            snippet: "b hit",
-            status: "open",
-            priority: "low",
-            dueDate: null,
-            url: "/w/workspace-alpha/tasks/task-1",
-          },
-        ],
-      },
-    },
+    status: workspaceScopedLoadedStatus,
     onSelectUrl: () => {},
   });
 

--- a/tests/unit/web-command-palette-search.test.ts
+++ b/tests/unit/web-command-palette-search.test.ts
@@ -145,10 +145,12 @@ test("buildCommandPaletteGroups annotates search results with icons and workspac
   const documentsGroup = groups.find((group) => group.id === "search-documents");
   const tasksGroup = groups.find((group) => group.id === "search-tasks");
 
-  assert.equal(documentsGroup?.items[0]?.icon, "📄");
-  assert.equal(documentsGroup?.items[0]?.pill, "Workspace");
-  assert.equal(tasksGroup?.items[0]?.icon, "✅");
-  assert.equal(tasksGroup?.items[0]?.pill, "Workspace");
+  assert.ok(documentsGroup);
+  assert.ok(tasksGroup);
+  assert.equal(documentsGroup.items[0].icon, "📄");
+  assert.equal(documentsGroup.items[0].pill, "Workspace");
+  assert.equal(tasksGroup.items[0].icon, "✅");
+  assert.equal(tasksGroup.items[0].pill, "Workspace");
 });
 
 test("buildCommandPaletteGroups shows empty state when both result groups are empty", () => {

--- a/tests/unit/web-command-palette-search.test.ts
+++ b/tests/unit/web-command-palette-search.test.ts
@@ -106,6 +106,49 @@ test("buildCommandPaletteGroups caps results to 5 per group and strips snippet m
   assert.equal(documentsGroup?.items[0]?.description?.includes("<mark>"), false);
 });
 
+test("buildCommandPaletteGroups annotates search results with icons and workspace pills when scoped", () => {
+  const groups = buildCommandPaletteGroups({
+    baseGroups: [],
+    normalizedQuery: "lo",
+    scope: "workspace",
+    status: {
+      kind: "loaded",
+      query: "lo",
+      results: {
+        documents: [
+          {
+            id: "doc-1",
+            title: "Doc 1",
+            snippet: "a hit",
+            updatedAt: "2025-07-17T12:10:00Z",
+            url: "/w/workspace-alpha/documents/doc-1",
+          },
+        ],
+        tasks: [
+          {
+            id: "task-1",
+            title: "Task 1",
+            snippet: "b hit",
+            status: "open",
+            priority: "low",
+            dueDate: null,
+            url: "/w/workspace-alpha/tasks/task-1",
+          },
+        ],
+      },
+    },
+    onSelectUrl: () => {},
+  });
+
+  const documentsGroup = groups.find((group) => group.id === "search-documents");
+  const tasksGroup = groups.find((group) => group.id === "search-tasks");
+
+  assert.equal(documentsGroup?.items[0]?.icon, "📄");
+  assert.equal(documentsGroup?.items[0]?.pill, "Workspace");
+  assert.equal(tasksGroup?.items[0]?.icon, "✅");
+  assert.equal(tasksGroup?.items[0]?.pill, "Workspace");
+});
+
 test("buildCommandPaletteGroups shows empty state when both result groups are empty", () => {
   const groups = buildCommandPaletteGroups({
     baseGroups: [{ id: "recent", label: "Recent", items: [] }],

--- a/tests/unit/web-command-palette.test.tsx
+++ b/tests/unit/web-command-palette.test.tsx
@@ -70,6 +70,37 @@ test("command palette renders a dialog with autofocus input and grouped results"
   assert.match(markup, /Create new workspace/);
 });
 
+test("command palette renders item icons and pills as aria-hidden decorations", () => {
+  const markup = renderToStaticMarkup(
+    <CommandPalette
+      groups={[
+        {
+          id: "documents",
+          label: "Documents",
+          items: [
+            {
+              id: "doc-intro",
+              icon: "📄",
+              label: "Introduction",
+              description: "Project Alpha",
+              pill: "Workspace",
+            },
+          ],
+        },
+      ]}
+      isOpen
+      onClose={() => {}}
+      query=""
+      onQueryChange={() => {}}
+    />,
+  );
+
+  assert.match(markup, /command-palette__item-icon/);
+  assert.match(markup, /aria-hidden=\"true\">📄/);
+  assert.match(markup, /command-palette__item-pill/);
+  assert.match(markup, /aria-hidden=\"true\">Workspace/);
+});
+
 test("globals.css keeps the command palette full-width on mobile and width-capped on tablet+", () => {
   assert.match(globalsCss, /\.command-palette__dialog \{/);
   assert.match(globalsCss, /\.command-palette__panel \{/);


### PR DESCRIPTION
## Linked Issue

Closes #257

## Summary

- Add a consistent icon column to command palette result items.
- Render a `Workspace` scope pill for search-backed results when on `/w/:workspaceId/*` routes.
- Keep existing result caps and baseline groups intact.

## Validation

- [x] `pnpm -w lint`
- [x] `pnpm typecheck`
- [x] `pnpm exec tsx --test tests/unit/web-command-palette.test.tsx`
- [x] `pnpm exec tsx --test tests/unit/web-command-palette-search.test.ts`
- [x] `pnpm test:unit`
- [x] `pnpm --filter @collabsphere/web run build`

## Risks / Notes

- none

## Handoff

- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

## Handoff Summary

- Command palette results render a consistent icon column and show a `Workspace` scope pill for search-backed results on workspace routes.

## Handoff Validation Evidence

- Commands run: `pnpm -w lint`, `pnpm typecheck`, `pnpm test:unit`, `pnpm --filter @collabsphere/web run build`

## Handoff Open Issues / Follow-ups

- none

## Handoff Risks / Deviations

- none

## Review Guidance

- Relevant spec / agent-ref docs: `docs/spec/03-information-architecture/03.5-command-palette.md`, `docs/agent-ref/ui/accessibility.md`, `docs/agent-ref/ui/responsive-rules.md`
- Areas that need extra scrutiny: icon + pill semantics (aria-hidden) and layout at mobile widths

## Local CodeRabbit CLI review outcome

- `pnpm review:coderabbit -- auth status` (logged in)
- `pnpm review:coderabbit -- review --type committed --base main` (No findings, before the CodeScene refactor follow-up commit)
- Follow-up `pnpm review:coderabbit -- review --type committed --base main` was rate-limited:

```text
[2026-04-10T18:07:09.510Z] ❌ ERROR: Error: Rate limit exceeded, please try after 7 minutes and 39 seconds
```
