### PR TITLE
docs(web): codify frontend governance contracts

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -1,23 +1,43 @@
 # AGENTS.md
 
 ## Purpose
-Local rules for the current `apps/web` Next.js App Router foundation and the downstream product frontend work that will extend it.
+Local hard rules for `apps/web` implementation work. These are the Tier A frontend governance rules and are intended to be enforceable in implementation and review.
 
 ## Scope
-`apps/web` App Router routes, layouts, placeholder pages, and deployment-facing web runtime during the PRJ-02 transition.
+`apps/web` routes, layouts, components, hooks, styling, tests, and prompt-contract expectations for web batons.
 
-## Must Follow
+## Tier A Hard Rules
+
+### Architecture And Runtime
 - Preserve the Next.js App Router foundation in `src/app`; do not reintroduce `src/index.html` as the web source-of-truth.
-- Treat the current routes/layouts as architectural foundation, not proof that downstream PRJ-02 feature stories are already complete.
-- Keep Vercel as the web deployment target and keep local/dev/build contracts truthful with the implemented Next runtime.
-- Every page must implement Loading, Empty, Error, and Loaded states.
+- Treat current routes and layouts as architectural foundation, not proof that downstream feature stories are already complete.
+- Keep Vercel as the web deployment target and keep local, dev, and build contracts truthful with the implemented Next runtime.
+- Do not invent frontend architecture that conflicts with canonical repo and spec docs.
+
+### Styling And Component Rules
+- Style from tokens first; do not introduce raw ad hoc colors in feature components when tokenized or semantic styling already exists.
+- Prefer source-owned UI primitives for standard interaction patterns; do not hand-build menu, dialog, sheet, popover, or command behaviors if the accepted primitive layer covers them.
+- Every page or major section must handle Loading, Empty, Error, and Loaded states when the surface is data-driven.
+- Keep responsive behavior and accessibility as first-class contracts, not afterthoughts.
+
+### Data And State Rules
 - Use TanStack Query for server state and mutations; follow optimistic update rules.
-- Respect auth/session boundaries; do not assume access outside API contracts.
+- Do not implement custom fetch-in-`useEffect` flows when query or mutation infrastructure already fits the use case.
+- Respect auth and session boundaries; do not assume access outside documented API contracts.
 - Until session and RBAC wiring lands, non-public route groups must deny by default and redirect to `/login` before protected UI renders.
 - Realtime app updates use Socket.IO; apply fallback polling intervals when sockets fail.
 - Document editor loads content via collab service (Hocuspocus), not REST.
-- Auth/session: expired sessions redirect to `/login` and show appropriate state.
+- Auth and session expiry must redirect to `/login` with appropriate UX state.
+
+### Interaction And Accessibility Rules
 - Accessibility and responsive rules are mandatory (WCAG 2.1 AA).
+- Interactive components must support keyboard navigation, focus visibility, semantic roles and labels, and coherent dismissal and restore behavior.
+- Behavior-first tests are required for interactive component changes; static markup checks alone are not sufficient.
+
+### Delivery And Review Rules
+- Frontend prompts and implementation should follow split-lane thinking when appropriate: UI composition, API integration, then validation.
+- Branch freshness is required before merge-readiness claims; stale-path reconciliation must happen before implementation expands.
+- PR, handoff, and closure comments must use clean markdown with truthful validation evidence.
 
 ## Never Do
 - Assume API fields or behaviors not in `docs/agent-ref/api/*`.
@@ -30,13 +50,16 @@ Local rules for the current `apps/web` Next.js App Router foundation and the dow
 - Add/update unit and component tests for UI behavior changes.
 - Validate page-state coverage (Loading/Empty/Error/Loaded).
 - Verify optimistic updates roll back correctly on errors.
+- Re-run affected validations after review-driven code changes.
 
 ## References
+- `apps/web/REVIEW.md`
 - `docs/agent-ref/ui/routes.md`
 - `docs/agent-ref/ui/page-states.md`
 - `docs/agent-ref/ui/component-patterns.md`
 - `docs/agent-ref/ui/accessibility.md`
 - `docs/agent-ref/ui/responsive-rules.md`
+- `docs/agent-ref/ops/frontend-baton-prompt-template.md`
 - `docs/agent-ref/api/document-endpoints.md`
 - `docs/agent-ref/api/task-endpoints.md`
 - `docs/agent-ref/api/comment-endpoints.md`

--- a/apps/web/REVIEW.md
+++ b/apps/web/REVIEW.md
@@ -17,7 +17,7 @@ Tier B frontend review defaults for `apps/web`. These guide review depth and qua
 
 ### Design And Visual Quality
 - Review for hierarchy, spacing rhythm, and state clarity, not just correctness.
-- Reject obviously generic AI-template aesthetics when the baton includes meaningful UI work.
+- When the baton includes meaningful UI work, evaluate the result against the design review rubric below and flag observable issues such as weak information hierarchy, inconsistent typographic scale, uneven spacing and composition, unclear state affordances, or poor product fit.
 - Art direction preferences are strong defaults, not hard merge blockers by themselves:
   - avoid purple or violet as the primary product accent unless explicitly requested
   - avoid decorative gradient-heavy chrome for core product surfaces

--- a/apps/web/REVIEW.md
+++ b/apps/web/REVIEW.md
@@ -1,0 +1,64 @@
+# REVIEW.md
+
+## Purpose
+Tier B frontend review defaults for `apps/web`. These guide review depth and quality expectations, but a reviewer may allow a deviation when the author documents a concrete rationale.
+
+## Review Defaults
+
+### Scope And Lane Clarity
+- The PR should make it obvious whether the baton is primarily UI composition, API integration, or validation.
+- Scope should stay narrow; unrelated cleanup should be rejected unless it removes a blocker inside the touched surface.
+- Stale issue-body paths should be reconciled up front instead of mirrored into new code.
+
+### Component And File Shape
+- Prefer feature-scoped files and extracted helpers when a single component becomes difficult to review.
+- Avoid growing one-off foundation components into catch-all surfaces.
+- Reuse shared state components and primitive layers before adding new ad hoc patterns.
+
+### Design And Visual Quality
+- Review for hierarchy, spacing rhythm, and state clarity, not just correctness.
+- Reject obviously generic AI-template aesthetics when the baton includes meaningful UI work.
+- Art direction preferences are strong defaults, not hard merge blockers by themselves:
+  - avoid purple or violet as the primary product accent unless explicitly requested
+  - avoid decorative gradient-heavy chrome for core product surfaces
+  - prefer the approved teal + warm stone direction and semantic color discipline
+
+### Responsive And Accessibility Expectations
+- Review at mobile and desktop breakpoints when layout or interaction changes.
+- Check touch-target sizing, overflow behavior, and focus order.
+- Verify reduced-motion handling when new motion is added.
+
+### Testing Expectations
+- Interactive components should have behavior-based coverage.
+- Prefer role-based queries and user interactions over implementation-detail assertions.
+- If a gap is consciously left open, the PR should state the gap and the risk.
+
+### Review Automation
+- Local CodeRabbit CLI should run before final push on materially changed branches.
+- Scanner or review-tool feedback is advisory until confirmed as a real current-head defect.
+- Late-arriving comments should be evaluated against current `main`, not blindly accepted.
+
+### PR And Handoff Quality
+- PR body must use the template, include correct issue linkage, and show concise validation evidence.
+- Handoff and closure comments must be valid markdown and factually current.
+- Merge-readiness should be asserted only from live checks and unresolved current-head threads.
+
+## Design Review Rubric
+- Visual distinctiveness
+- Information hierarchy
+- Typography quality
+- Spacing and composition
+- Responsive integrity
+- Accessibility quality
+- State quality
+- Interaction polish
+- Implementation cleanliness
+- Product fit
+
+## References
+- `apps/web/AGENTS.md`
+- `docs/agent-ref/ui/accessibility.md`
+- `docs/agent-ref/ui/component-patterns.md`
+- `docs/agent-ref/ui/page-states.md`
+- `docs/agent-ref/ui/responsive-rules.md`
+- `docs/agent-ref/ops/pr-review-workflow.md`

--- a/docs/agent-ref/ops/frontend-baton-prompt-template.md
+++ b/docs/agent-ref/ops/frontend-baton-prompt-template.md
@@ -1,0 +1,66 @@
+# Frontend Baton Prompt Template
+
+## Purpose
+Provide a concise prompt contract for frontend batons that preserves governance, validation, and merge quality without unnecessary token burn.
+
+## Required Sections
+
+### 1. Worktree And Baton
+- worktree path
+- active issue number and title
+- parent story or chain context if relevant
+
+### 2. Minimal Live Baseline
+- issue state checks
+- existing PR check for the same baton
+- git branch freshness check
+- only the live checks needed to prove the baton is runnable
+
+### 3. Execution Goal
+- one clear sentence describing the user-visible or governance-visible outcome
+
+### 4. Scope
+- touched surfaces to prefer
+- stale or dead paths to ignore
+- explicit in-scope and out-of-scope boundaries
+
+### 5. Decision Rules
+- rules specific to the baton
+- acceptance-critical behaviors or constraints
+- any split-lane guidance if UI and API work are separated
+
+### 6. Validation
+- exact required commands
+- note when targeted tests are required in addition to repo-wide commands
+
+### 7. Review And Merge Rules
+- local CodeRabbit CLI requirement
+- PR template requirement
+- linked issue closing keyword
+- handoff or closure comment requirement
+- live merge-readiness based on checks and unresolved current-head review threads only
+
+### 8. Required Report
+- target report path in `D:\coloe\decision`
+- concise required sections
+
+## Prompt Style Rules
+- prefer minimal baseline checks; do not paste large issue bodies when a state check is enough
+- prefer real live-tree paths over stale issue file tables
+- require concise evidence rather than full CI or CLI dumps unless failure proof matters
+- keep markdown clean and copy-pasteable
+- do not ask the implementer to hand back the baton while in-scope review cleanup is still executable
+
+## Default Report Sections
+1. live baseline reconciliation
+2. scope implemented
+3. files changed with rationale
+4. validation results
+5. local CodeRabbit findings and outcomes
+6. risks and follow-ups
+7. merge-readiness assessment
+
+## Related Files
+- `apps/web/AGENTS.md`
+- `apps/web/REVIEW.md`
+- `docs/agent-ref/ops/pr-review-workflow.md`

--- a/docs/agent-ref/ops/frontend-baton-prompt-template.md
+++ b/docs/agent-ref/ops/frontend-baton-prompt-template.md
@@ -41,7 +41,7 @@ Provide a concise prompt contract for frontend batons that preserves governance,
 - live merge-readiness based on checks and unresolved current-head review threads only
 
 ### 8. Required Report
-- target report path in `D:\coloe\decision`
+- target report path or report naming convention for the active workflow
 - concise required sections
 
 ## Prompt Style Rules

--- a/docs/agent-ref/ops/pr-review-workflow.md
+++ b/docs/agent-ref/ops/pr-review-workflow.md
@@ -17,6 +17,7 @@ Define the expected branch, PR, review, and merge workflow for CollabSphere deli
 - Every PR should map to one issue.
 - Every issue should have one active working branch at a time.
 - Validation evidence is required in the PR description or linked issue/handoff.
+- Merge claims should be based on live checks and unresolved current-head review threads, not stale report text.
 
 ## Branch Naming
 
@@ -49,8 +50,19 @@ Every PR should include:
 - validation commands and outcomes
 - risks, waivers, or follow-ups
 - handoff note if the issue requires one
+- concise markdown only; no malformed literal `\n`, broken checklists, or pseudo-markdown
 
 Use `.github/pull_request_template.md`.
+
+## Frontend Baton Contract
+
+For frontend-heavy batons:
+
+- reconcile stale issue-body paths against the live tree before implementation expands
+- keep prompt scope explicit about UI composition, API integration, or validation focus
+- do not hand the baton back while more in-scope implementation or review cleanup is still executable
+- prefer concise evidence over large pasted logs
+- require local CodeRabbit CLI review before final push when the branch changed materially
 
 ## Review Sources
 
@@ -89,6 +101,7 @@ After review-driven changes:
 - re-run local CodeRabbit CLI review (`pnpm review:coderabbit`) when touched files changed materially
 - update the PR summary if behavior changed
 - update the handoff if risks or follow-ups changed
+- resolve or explicitly disposition late-arriving current-head comments before asserting merge-readiness
 
 ## Merge Rules
 
@@ -98,6 +111,13 @@ Do not merge until:
 - review state is acceptable for the issue risk level
 - validation evidence is present
 - required handoff details are captured
+- current-head unresolved review threads are cleared or explicitly dispositioned
+- branch freshness is acceptable for the target branch
+
+Merge method:
+
+- prefer squash merge for normal delivery work
+- delete the feature branch after merge
 
 ## Elevated and Critical Work
 
@@ -115,3 +135,4 @@ For `review:elevated` or `review:critical` work:
 - `docs/agent-ref/ops/handoff-format.md`
 - `docs/agent-ref/ops/branch-protection.md`
 - `docs/agent-ref/ops/review-automation.md`
+- `docs/agent-ref/ops/frontend-baton-prompt-template.md`


### PR DESCRIPTION
## Linked Issue

Closes #1550

## Summary

- codified Tier A hard frontend rules in `apps/web/AGENTS.md`
- added `apps/web/REVIEW.md` for Tier B review defaults and rubric
- added `docs/agent-ref/ops/frontend-baton-prompt-template.md` and aligned `pr-review-workflow.md`

## Governance Contract Changes

- split frontend governance into hard rules, review defaults, and prompt-contract guidance
- added explicit frontend baton expectations for stale-path reconciliation, concise evidence, and late-review cleanup
- formalized squash-merge and branch-deletion expectations for normal delivery work

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm review:coderabbit -- auth status`
- [x] `pnpm review:coderabbit -- review --type committed --base main`

## Risks / Notes

- `review:critical` on #1550 still requires human approval before merge
- local workspace contains unrelated untracked `.agent/*` artifacts that were not modified or included in this PR

## Handoff

- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

## Handoff Summary

- governance contracts are now codified for `apps/web` and PR review workflow

## Handoff Validation Evidence

- `pnpm lint`
- `pnpm typecheck`
- `pnpm review:coderabbit -- review --type committed --base main` -> no findings

## Handoff Open Issues / Follow-ups

- human approval and normal PR review remain before merge because the task is `review:critical`

## Handoff Risks / Deviations

- none

## Review Guidance

- Relevant spec / agent-ref docs: `apps/web/AGENTS.md`, `apps/web/REVIEW.md`, `docs/agent-ref/ops/pr-review-workflow.md`, `docs/agent-ref/ops/frontend-baton-prompt-template.md`
- Areas that need extra scrutiny: rule clarity, overlap avoidance, and whether the new hard-rule wording is enforceable without conflicting with current repo behavior

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rick1330/collabsphere/pull/1556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
