### PR TITLE
refactor(web): extract shell presentation from globals

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -262,6 +262,10 @@ button {
   min-width: 0;
 }
 
+.top-nav {
+  grid-template-areas: "brand workspace search actions";
+}
+
 .top-nav__brand-label,
 .top-nav__control-label,
 .notification-bell__label {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -62,44 +62,6 @@ button {
   outline-offset: 2px;
 }
 
-.shell {
-  display: grid;
-  grid-template-columns: minmax(18rem, 24rem) 1fr;
-  min-height: 100vh;
-}
-
-.shell--no-rail {
-  grid-template-columns: 1fr;
-}
-
-.shell__rail,
-.shell__content {
-  padding: 1.5rem;
-}
-
-.shell__rail--default {
-  display: grid;
-  gap: 1.5rem;
-  align-content: start;
-}
-
-.shell__rail {
-  position: relative;
-  color: var(--color-text-primary);
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(
-        in srgb,
-        var(--section-accent, var(--color-accent)) 12%,
-        var(--surface-card-subtle)
-      ) 0%,
-      color-mix(in srgb, var(--section-accent, var(--color-accent)) 4%, var(--surface-card))
-        100%
-    );
-  border-inline-end: 1px solid var(--border-subtle);
-}
-
 .shell__rail::before {
   content: "";
   position: absolute;
@@ -135,56 +97,12 @@ button {
   --section-accent: var(--tone-admin);
 }
 
-.shell__eyebrow {
-  margin: 0 0 0.75rem;
-  font-size: 0.8rem;
-  font-weight: 700;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--color-text-tertiary);
-}
-
-.shell__title {
-  margin: 0;
-  font-size: clamp(2rem, 3vw, 3rem);
-  line-height: 1.05;
-  letter-spacing: -0.04em;
-}
-
-.shell__description,
 .shell__header-copy,
 .placeholder-card__summary,
 .status-banner p,
 .placeholder-card__list,
 .path-list {
   color: var(--color-text-secondary);
-}
-
-.shell__description {
-  max-width: 28ch;
-}
-
-.shell__nav {
-  margin-top: 2rem;
-}
-
-.shell__nav-list {
-  display: grid;
-  gap: 0.85rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.shell__nav-link {
-  display: grid;
-  gap: 0.15rem;
-  padding: 1rem 1.1rem;
-  border-radius: var(--radius-md);
-  text-decoration: none;
-  background: var(--surface-card);
-  border: 1px solid var(--border-subtle);
-  box-shadow: var(--shadow-soft);
 }
 
 .shell__nav-link:hover,
@@ -216,62 +134,8 @@ button {
   outline-offset: 2px;
 }
 
-.shell__nav-hint {
-  font-size: 0.9rem;
-  color: var(--color-text-secondary);
-}
-
 .sidebar-collapse-toggle {
   display: none;
-}
-
-.global-sidebar {
-  display: grid;
-  gap: 1.35rem;
-  align-content: start;
-}
-
-.global-sidebar__header,
-.global-sidebar__nav {
-  display: grid;
-  gap: 1rem;
-}
-
-.global-sidebar__title {
-  font-size: clamp(1.9rem, 2.4vw, 2.6rem);
-}
-
-.global-sidebar__description {
-  margin: 0;
-  max-width: 30ch;
-}
-
-.global-sidebar__section {
-  display: grid;
-  gap: 0.7rem;
-}
-
-.global-sidebar__section-label,
-.global-sidebar__supplement-label {
-  margin: 0;
-  font-size: 0.76rem;
-  font-weight: 700;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--color-text-tertiary);
-}
-
-.global-sidebar__list {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.global-sidebar__link {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  gap: 0.8rem;
-  align-items: center;
-  text-decoration: none;
 }
 
 .global-sidebar__link:hover,
@@ -288,101 +152,6 @@ button {
   outline-offset: 2px;
 }
 
-.global-sidebar__link-mark {
-  display: inline-grid;
-  place-items: center;
-  width: 2.4rem;
-  min-height: 2.4rem;
-  border-radius: 0.9rem;
-  background:
-    linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--section-accent, var(--color-accent)) 20%, var(--surface-card)),
-      color-mix(in srgb, var(--surface-card-subtle) 92%, var(--surface-card))
-    );
-  color: var(--color-text-secondary);
-  font-size: 0.72rem;
-  font-weight: 800;
-  letter-spacing: 0.08em;
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-border) 62%, transparent);
-}
-
-.global-sidebar__link-copy {
-  display: grid;
-  gap: 0.16rem;
-  min-width: 0;
-}
-
-.global-sidebar__link-label {
-  font-weight: 700;
-  color: var(--color-text-primary);
-}
-
-.global-sidebar__link-description {
-  color: var(--color-text-secondary);
-  font-size: 0.88rem;
-}
-
-.global-sidebar__link-tag {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  align-self: start;
-  min-width: 3.4rem;
-  padding: 0.28rem 0.55rem;
-  border-radius: 999px;
-  background:
-    color-mix(in srgb, var(--section-accent, var(--color-accent)) 14%, var(--surface-card));
-  color: var(--color-text-secondary);
-  font-size: 0.75rem;
-  font-weight: 700;
-}
-
-.global-sidebar__supplement {
-  display: grid;
-  gap: 0.55rem;
-  padding: 1rem 1.05rem;
-  border-radius: 1.05rem;
-  border: 1px solid var(--border-subtle);
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--surface-card) 94%, var(--color-bg-secondary)) 0%,
-      color-mix(in srgb, var(--surface-card-subtle) 88%, var(--surface-card)) 100%
-    );
-  box-shadow: var(--shadow-soft);
-}
-
-.global-sidebar__supplement-copy {
-  margin: 0;
-  color: var(--color-text-secondary);
-  font-size: 0.9rem;
-}
-
-.workspace-sidebar {
-  display: grid;
-  gap: 1.35rem;
-  align-content: start;
-}
-
-.workspace-sidebar__header,
-.workspace-sidebar__nav {
-  display: grid;
-  gap: 1rem;
-}
-
-.workspace-sidebar__back-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  width: fit-content;
-  padding: 0.45rem 0.7rem;
-  border-radius: 999px;
-  text-decoration: none;
-  color: var(--color-text-secondary);
-  background:
-    color-mix(in srgb, var(--section-accent, var(--color-accent)) 7%, var(--surface-card));
-}
 
 .workspace-sidebar__back-link:hover,
 .workspace-sidebar__back-link:focus-visible {
@@ -393,121 +162,6 @@ button {
 .workspace-sidebar__back-link:focus-visible {
   outline: 2px solid var(--focus-ring-color);
   outline-offset: 2px;
-}
-
-.workspace-sidebar__identity {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.85rem;
-  align-items: start;
-}
-
-.workspace-sidebar__identity-mark {
-  display: inline-grid;
-  place-items: center;
-  width: 2.7rem;
-  height: 2.7rem;
-  border-radius: 1rem;
-  background:
-    linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--section-accent, var(--color-accent)) 78%, white),
-      color-mix(in srgb, var(--section-accent, var(--color-accent)) 24%, transparent)
-    );
-  color: var(--color-bg-primary);
-  font-size: 0.92rem;
-  font-weight: 800;
-  letter-spacing: 0.08em;
-}
-
-.workspace-sidebar__identity-copy {
-  display: grid;
-  gap: 0.25rem;
-  min-width: 0;
-}
-
-.workspace-sidebar__title,
-.workspace-sidebar__description {
-  margin: 0;
-}
-
-.workspace-sidebar__title {
-  font-size: 1.15rem;
-  font-weight: 800;
-  color: var(--color-text-primary);
-}
-
-.workspace-sidebar__description {
-  color: var(--color-text-secondary);
-  font-size: 0.9rem;
-}
-
-.workspace-sidebar__role-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-self: start;
-  margin-left: 3.55rem;
-  padding: 0.24rem 0.6rem;
-  border-radius: 999px;
-  background:
-    color-mix(in srgb, var(--section-accent, var(--color-accent)) 14%, var(--surface-card));
-  color: var(--color-text-secondary);
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.workspace-sidebar__status {
-  display: grid;
-  gap: 0.4rem;
-  padding: 0.95rem 1rem;
-  border-radius: 1rem;
-  border: 1px solid var(--border-subtle);
-  background: var(--surface-card);
-}
-
-.workspace-sidebar__status-title,
-.workspace-sidebar__status-copy,
-.workspace-sidebar__status-meta {
-  margin: 0;
-}
-
-.workspace-sidebar__status-copy,
-.workspace-sidebar__status-meta {
-  color: var(--color-text-secondary);
-  font-size: 0.88rem;
-}
-
-.workspace-sidebar__section {
-  display: grid;
-  gap: 0.7rem;
-}
-
-.workspace-sidebar__section-label {
-  margin: 0;
-  font-size: 0.76rem;
-  font-weight: 700;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--color-text-tertiary);
-}
-
-.workspace-sidebar__list {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.workspace-sidebar__link,
-.workspace-sidebar__locked {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.8rem;
-  align-items: center;
-}
-
-.workspace-sidebar__link {
-  text-decoration: none;
 }
 
 .workspace-sidebar__link:hover {
@@ -528,137 +182,11 @@ button {
   outline-offset: 2px;
 }
 
-.workspace-sidebar__locked {
-  padding: 1rem 1.1rem;
-  border-radius: var(--radius-md);
-  border: 1px dashed
-    color-mix(in srgb, var(--color-border) 82%, var(--section-accent, var(--color-accent)) 18%);
-  background:
-    color-mix(in srgb, var(--section-accent, var(--color-accent)) 4%, var(--surface-card));
-}
-
 .workspace-sidebar__locked[data-locked="true"] {
   border-color:
     color-mix(in srgb, var(--color-warning) 28%, var(--border-subtle));
   background:
     color-mix(in srgb, var(--color-warning) 7%, var(--surface-card));
-}
-
-.workspace-sidebar__link-mark {
-  display: inline-grid;
-  place-items: center;
-  width: 2.4rem;
-  min-height: 2.4rem;
-  border-radius: 0.9rem;
-  background:
-    linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--section-accent, var(--color-accent)) 20%, var(--surface-card)),
-      color-mix(in srgb, var(--surface-card-subtle) 92%, var(--surface-card))
-    );
-  color: var(--color-text-secondary);
-  font-size: 0.76rem;
-  font-weight: 800;
-  letter-spacing: 0.08em;
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-border) 62%, transparent);
-}
-
-.workspace-sidebar__link-copy {
-  display: grid;
-  gap: 0.18rem;
-  min-width: 0;
-}
-
-.workspace-sidebar__link-label-row {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  min-width: 0;
-}
-
-.workspace-sidebar__link-label {
-  font-weight: 700;
-  color: var(--color-text-primary);
-}
-
-.workspace-sidebar__link-description {
-  color: var(--color-text-secondary);
-  font-size: 0.88rem;
-}
-
-.workspace-sidebar__gate-tag {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.2rem 0.5rem;
-  border-radius: 999px;
-  background:
-    color-mix(in srgb, var(--section-accent, var(--color-accent)) 12%, var(--surface-card));
-  color: var(--color-text-secondary);
-  font-size: 0.74rem;
-  font-weight: 700;
-  white-space: nowrap;
-}
-
-.shell__content {
-  display: grid;
-  grid-template-rows: auto 1fr;
-  gap: 1.5rem;
-}
-
-.shell__content--with-top-nav {
-  grid-template-rows: auto auto 1fr;
-}
-
-.top-nav {
-  position: sticky;
-  top: 1rem;
-  z-index: 6;
-  display: grid;
-  grid-template-columns: minmax(0, 1.1fr) minmax(14rem, 18rem) minmax(18rem, 1fr) auto;
-  grid-template-areas: "brand workspace search actions";
-  gap: 0.9rem;
-  align-items: center;
-  padding: 1rem 1.1rem;
-  border-radius: 1.45rem;
-  border: 1px solid
-    color-mix(in srgb, var(--section-accent, var(--color-accent)) 18%, var(--color-border));
-  background:
-    linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--surface-card) 94%, var(--surface-card-subtle)) 0%,
-      color-mix(
-          in srgb,
-          var(--surface-card-subtle) 86%,
-          var(--section-accent, var(--color-accent))
-        )
-        100%
-    );
-  box-shadow: var(--shadow-elevated);
-  backdrop-filter: blur(18px);
-}
-
-.top-nav__brand-cluster {
-  grid-area: brand;
-  display: grid;
-  gap: 0.45rem;
-  min-width: 0;
-}
-
-.top-nav__brand-row {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.75rem;
-  align-items: center;
-}
-
-.top-nav__brand {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.8rem;
-  align-items: center;
-  max-width: fit-content;
-  text-decoration: none;
 }
 
 .top-nav__brand:focus-visible,
@@ -752,23 +280,6 @@ button {
 .notification-bell__state-meta {
   color: var(--color-text-secondary);
   font-size: 0.9rem;
-}
-
-.top-nav__context-note {
-  margin: 0;
-  max-width: 40ch;
-}
-
-.top-nav__workspace-slot {
-  grid-area: workspace;
-}
-
-.top-nav__search {
-  grid-area: search;
-}
-
-.top-nav__search--desktop-only {
-  display: block;
 }
 
 .mobile-menu__dialog,
@@ -1205,39 +716,6 @@ button {
   }
 }
 
-.workspace-switcher {
-  position: relative;
-}
-
-.workspace-switcher__trigger {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto auto;
-  gap: 0.7rem;
-  align-items: center;
-  width: 100%;
-  min-height: 4rem;
-  padding: 0.8rem 0.9rem;
-  border-radius: 1.15rem;
-  border: 1px solid
-    color-mix(in srgb, var(--color-border) 78%, var(--section-accent, var(--color-accent)) 22%);
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--surface-card) 94%, var(--color-bg-secondary)) 0%,
-      color-mix(
-          in srgb,
-          var(--surface-card-subtle) 88%,
-          var(--section-accent, var(--color-accent))
-        )
-        100%
-    );
-  box-shadow: var(--shadow-soft);
-  color: inherit;
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
-}
-
 .workspace-switcher__trigger:hover,
 .workspace-switcher__trigger:focus-visible {
   transform: translateY(-1px);
@@ -1252,182 +730,9 @@ button {
   outline-offset: 2px;
 }
 
-.workspace-switcher__trigger-mark,
-.workspace-switcher__item-mark {
-  display: inline-grid;
-  place-items: center;
-  width: 2.45rem;
-  height: 2.45rem;
-  border-radius: 999px;
-  background:
-    linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--section-accent, var(--color-accent)) 80%, white),
-      color-mix(in srgb, var(--section-accent, var(--color-accent)) 24%, transparent)
-    );
-  color: var(--color-bg-primary);
-  font-size: 0.84rem;
-  font-weight: 800;
-  letter-spacing: 0.06em;
-  box-shadow:
-    inset 0 1px 0 color-mix(in srgb, white 30%, transparent),
-    0 0 0 1px color-mix(in srgb, var(--section-accent, var(--color-accent)) 24%, transparent);
-}
-
-.workspace-switcher__trigger-copy,
-.workspace-switcher__item-copy {
-  display: grid;
-  gap: 0.16rem;
-  min-width: 0;
-}
-
-.workspace-switcher__trigger-label,
-.workspace-switcher__item-label {
-  font-size: 0.98rem;
-  font-weight: 700;
-  color: var(--color-text-primary);
-}
-
-.workspace-switcher__trigger-meta,
-.workspace-switcher__item-description,
-.workspace-switcher__state-copy,
-.workspace-switcher__state-meta {
-  color: var(--color-text-secondary);
-  font-size: 0.86rem;
-}
-
-.workspace-switcher__trigger-caret {
-  color: var(--color-text-tertiary);
-  font-size: 0.88rem;
-}
-
-.workspace-switcher__panel {
-  position: absolute;
-  inset: calc(100% + 0.7rem) auto auto 0;
-  z-index: 8;
-  width: min(28rem, calc(100vw - 3rem));
-  max-height: min(32rem, calc(100vh - 6rem));
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  padding: 1rem;
-  border-radius: 1.35rem;
-  border: 1px solid
-    color-mix(in srgb, var(--color-border) 80%, var(--section-accent, var(--color-accent)) 20%);
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--surface-card) 96%, var(--color-bg-secondary)) 0%,
-      color-mix(
-          in srgb,
-          var(--surface-card-subtle) 92%,
-          var(--section-accent, var(--color-accent))
-        )
-        100%
-    );
-  box-shadow: var(--shadow-elevated);
-}
-
-.workspace-switcher__panel-header {
-  display: grid;
-  gap: 0.28rem;
-  margin-bottom: 0.85rem;
-}
-
-.workspace-switcher__panel-eyebrow {
-  margin: 0;
-  font-size: 0.76rem;
-  font-weight: 700;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--color-text-tertiary);
-}
-
-.workspace-switcher__panel-title,
-.workspace-switcher__state-title {
-  margin: 0;
-  color: var(--color-text-primary);
-  font-size: 0.98rem;
-  font-weight: 700;
-}
-
-.workspace-switcher__state {
-  display: grid;
-  gap: 0.5rem;
-  margin-bottom: 0.85rem;
-  padding: 0.95rem 1rem;
-  border-radius: 1rem;
-  border: 1px solid var(--border-subtle);
-  background: var(--surface-card);
-}
-
-.workspace-switcher__state-copy,
-.workspace-switcher__state-meta {
-  margin: 0;
-}
-
 .workspace-switcher__state--error {
   border-color:
     color-mix(in srgb, var(--color-accent) 24%, var(--border-subtle));
-}
-
-.workspace-switcher__skeleton-list {
-  display: grid;
-  gap: 0.7rem;
-}
-
-.workspace-switcher__skeleton-row {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.8rem;
-  align-items: center;
-}
-
-.workspace-switcher__skeleton-mark {
-  width: 2.45rem;
-  height: 2.45rem;
-  border-radius: 999px;
-  background: var(--surface-card-muted);
-}
-
-.workspace-switcher__skeleton-copy {
-  display: grid;
-  gap: 0.35rem;
-}
-
-.workspace-switcher__skeleton-line {
-  display: block;
-  height: 0.7rem;
-  border-radius: 999px;
-  background: var(--surface-card-muted);
-}
-
-.workspace-switcher__skeleton-line--primary {
-  width: 58%;
-}
-
-.workspace-switcher__skeleton-line--secondary {
-  width: 76%;
-}
-
-.workspace-switcher__menu {
-  display: grid;
-  gap: 0.55rem;
-}
-
-.workspace-switcher__item {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.8rem;
-  align-items: center;
-  width: 100%;
-  padding: 0.9rem 0.95rem;
-  border-radius: 1rem;
-  border: 1px solid var(--border-subtle);
-  background: var(--surface-card);
-  color: inherit;
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
 }
 
 .workspace-switcher__item:hover,
@@ -1448,24 +753,6 @@ button {
       color-mix(in srgb, var(--section-accent, var(--color-accent)) 10%, var(--surface-card)) 0%,
       color-mix(in srgb, var(--section-accent, var(--color-accent)) 4%, var(--surface-card)) 100%
     );
-}
-
-.workspace-switcher__item-label-row {
-  display: flex;
-  align-items: center;
-  gap: 0.55rem;
-  min-width: 0;
-}
-
-.workspace-switcher__item-badge {
-  padding: 0.18rem 0.48rem;
-  border-radius: 999px;
-  background:
-    color-mix(in srgb, var(--section-accent, var(--color-accent)) 16%, var(--surface-card));
-  color: var(--color-text-secondary);
-  font-size: 0.74rem;
-  font-weight: 700;
-  white-space: nowrap;
 }
 
 .notification-bell {
@@ -1727,43 +1014,10 @@ button {
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--section-accent, var(--color-accent)) 16%, transparent);
 }
 
-.top-nav__actions {
-  grid-area: actions;
-  display: flex;
-  gap: 0.75rem;
-  align-items: stretch;
-  justify-content: flex-end;
-}
-
 .top-nav__actions > .notification-bell,
 .top-nav__user-slot,
 .top-nav__actions > .top-nav__control {
   flex: 0 1 auto;
-}
-
-.top-nav__control,
-.top-nav__search-trigger {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  gap: 0.75rem;
-  align-items: center;
-  width: 100%;
-  min-height: 4rem;
-  padding: 0.8rem 0.9rem;
-  border-radius: 1.15rem;
-  border: 1px solid
-    color-mix(in srgb, var(--color-border) 82%, var(--section-accent, var(--color-accent)) 18%);
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--surface-card) 92%, var(--color-bg-secondary)) 0%,
-      color-mix(in srgb, var(--surface-card-subtle) 84%, var(--surface-card)) 100%
-    );
-  box-shadow: var(--shadow-soft);
-  color: inherit;
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
 }
 
 .top-nav__control:disabled,

--- a/apps/web/src/components/shell/global-sidebar.tsx
+++ b/apps/web/src/components/shell/global-sidebar.tsx
@@ -30,6 +30,28 @@ type GlobalSidebarViewProps = SidebarCollapseProps & {
   primaryItems?: readonly GlobalSidebarItem[];
 };
 
+const globalSidebarMarkStyle = {
+  background: `linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--section-accent, var(--color-accent)) 20%, var(--surface-card)),
+    color-mix(in srgb, var(--surface-card-subtle) 92%, var(--surface-card))
+  )`,
+  boxShadow: `inset 0 0 0 1px color-mix(in srgb, var(--color-border) 62%, transparent)`,
+} satisfies React.CSSProperties;
+
+const globalSidebarTagStyle = {
+  background: `color-mix(in srgb, var(--section-accent, var(--color-accent)) 14%, var(--surface-card))`,
+} satisfies React.CSSProperties;
+
+const globalSidebarSupplementStyle = {
+  background: `linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--surface-card) 94%, var(--color-bg-secondary)) 0%,
+    color-mix(in srgb, var(--surface-card-subtle) 88%, var(--surface-card)) 100%
+  )`,
+  boxShadow: "var(--shadow-soft)",
+} satisfies React.CSSProperties;
+
 function GlobalSidebarSection({
   collapsed,
   currentPathname,
@@ -37,34 +59,51 @@ function GlobalSidebarSection({
   label,
 }: Readonly<GlobalSidebarSectionProps>) {
   return (
-    <section className="global-sidebar__section" aria-labelledby={`global-sidebar-${label}`}>
-      <p id={`global-sidebar-${label}`} className="global-sidebar__section-label">
+    <section
+      className="global-sidebar__section grid gap-[0.7rem]"
+      aria-labelledby={`global-sidebar-${label}`}
+    >
+      <p
+        id={`global-sidebar-${label}`}
+        className="global-sidebar__section-label m-0 text-[0.76rem] font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-tertiary)]"
+      >
         {label}
       </p>
-      <ul className="shell__nav-list global-sidebar__list">
+      <ul className="shell__nav-list global-sidebar__list m-0 grid list-none gap-3 p-0">
         {items.map((item) => {
           const isActive = isGlobalSidebarItemActive(currentPathname, item);
 
           return (
             <li key={item.href} className="shell__nav-item">
               <Link
-                className="shell__nav-link global-sidebar__link"
+                className="shell__nav-link global-sidebar__link grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 rounded-[var(--radius-md)] border border-[color:var(--border-subtle)] bg-[var(--surface-card)] px-[1.1rem] py-4 no-underline shadow-[var(--shadow-soft)]"
                 data-active={isActive}
                 aria-current={isActive ? "page" : undefined}
                 aria-label={collapsed ? item.label : undefined}
                 href={item.href}
                 title={collapsed ? item.label : undefined}
               >
-                <span className="global-sidebar__link-mark" aria-hidden="true">
+                <span
+                  className="global-sidebar__link-mark inline-grid min-h-10 w-10 place-items-center rounded-[0.9rem] text-[0.72rem] font-extrabold tracking-[0.08em] text-[color:var(--color-text-secondary)]"
+                  style={globalSidebarMarkStyle}
+                  aria-hidden="true"
+                >
                   {item.mark}
                 </span>
-                <span className="global-sidebar__link-copy">
-                  <span className="global-sidebar__link-label">{item.label}</span>
-                  <span className="global-sidebar__link-description">
+                <span className="global-sidebar__link-copy grid min-w-0 gap-[0.16rem]">
+                  <span className="global-sidebar__link-label font-bold text-[color:var(--color-text-primary)]">
+                    {item.label}
+                  </span>
+                  <span className="global-sidebar__link-description text-[0.88rem] text-[color:var(--color-text-secondary)]">
                     {item.description}
                   </span>
                 </span>
-                <span className="global-sidebar__link-tag">{item.tag}</span>
+                <span
+                  className="global-sidebar__link-tag inline-flex min-w-[3.4rem] items-center justify-center self-start rounded-full px-[0.55rem] py-[0.28rem] text-[0.75rem] font-bold text-[color:var(--color-text-secondary)]"
+                  style={globalSidebarTagStyle}
+                >
+                  {item.tag}
+                </span>
               </Link>
             </li>
           );
@@ -88,7 +127,14 @@ export function GlobalSidebarView({
   return (
     <aside
       id={effectiveSidebarId}
-      className="shell__rail global-sidebar"
+      className="shell__rail global-sidebar relative grid content-start gap-[1.35rem] border-r border-[color:var(--border-subtle)] px-6 py-6 text-[color:var(--color-text-primary)]"
+      style={{
+        background: `linear-gradient(
+          180deg,
+          color-mix(in srgb, var(--section-accent, var(--color-accent)) 12%, var(--surface-card-subtle)) 0%,
+          color-mix(in srgb, var(--section-accent, var(--color-accent)) 4%, var(--surface-card)) 100%
+        )`,
+      }}
       aria-label="Global navigation"
       data-collapsed={collapsed}
     >
@@ -105,16 +151,20 @@ export function GlobalSidebarView({
           <span aria-hidden="true">{collapsed ? ">" : "<"}</span>
         </button>
       ) : null}
-      <div className="global-sidebar__header">
-        <p className="shell__eyebrow">Global navigation</p>
-        <h1 className="shell__title global-sidebar__title">CollabSphere</h1>
-        <p className="shell__description global-sidebar__description">
+      <div className="global-sidebar__header grid gap-4">
+        <p className="shell__eyebrow m-0 text-[0.8rem] font-bold uppercase tracking-[0.16em] text-[color:var(--color-text-tertiary)]">
+          Global navigation
+        </p>
+        <h1 className="shell__title global-sidebar__title m-0 text-[clamp(1.9rem,2.4vw,2.6rem)] leading-[1.05] tracking-[-0.04em]">
+          CollabSphere
+        </h1>
+        <p className="shell__description global-sidebar__description m-0 max-w-[30ch] text-[color:var(--color-text-secondary)]">
           Persistent global routing now lives beside the top nav so authenticated
           pages keep orientation without inventing workspace-only context.
         </p>
       </div>
 
-      <nav className="global-sidebar__nav" aria-label="Global routes">
+      <nav className="global-sidebar__nav grid gap-4" aria-label="Global routes">
         <GlobalSidebarSection
           collapsed={collapsed}
           currentPathname={currentPathname}
@@ -129,11 +179,18 @@ export function GlobalSidebarView({
         />
       </nav>
 
-      <section className="global-sidebar__supplement" aria-labelledby="global-sidebar-recent">
-        <p id="global-sidebar-recent" className="global-sidebar__supplement-label">
+      <section
+        className="global-sidebar__supplement grid gap-[0.55rem] rounded-[1.05rem] border border-[color:var(--border-subtle)] px-[1.05rem] py-4"
+        style={globalSidebarSupplementStyle}
+        aria-labelledby="global-sidebar-recent"
+      >
+        <p
+          id="global-sidebar-recent"
+          className="global-sidebar__supplement-label m-0 text-[0.76rem] font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-tertiary)]"
+        >
           Recent workspaces
         </p>
-        <p className="global-sidebar__supplement-copy">
+        <p className="global-sidebar__supplement-copy m-0 text-[0.9rem] text-[color:var(--color-text-secondary)]">
           The live top-nav workspace switcher remains the truthful recent-workspace
           entrypoint until dedicated sidebar history lands in a later baton.
         </p>

--- a/apps/web/src/components/shell/shell-frame-view.tsx
+++ b/apps/web/src/components/shell/shell-frame-view.tsx
@@ -22,6 +22,14 @@ type ShellFrameViewProps = ShellFrameProps & {
   dataSidebarState?: DesktopSidebarMode;
 };
 
+const shellRailSurfaceStyle = {
+  background: `linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--section-accent, var(--color-accent)) 12%, var(--surface-card-subtle)) 0%,
+    color-mix(in srgb, var(--section-accent, var(--color-accent)) 4%, var(--surface-card)) 100%
+  )`,
+} satisfies React.CSSProperties;
+
 export function ShellFrameView({
   tone,
   sectionLabel,
@@ -42,21 +50,38 @@ export function ShellFrameView({
     `shell--${tone}`,
     topNav == null ? null : "shell--has-top-nav",
     isRailOmitted ? "shell--no-rail" : null,
+    "grid min-h-screen",
+    isRailOmitted ? "grid-cols-1" : "grid-cols-[minmax(18rem,24rem)_1fr]",
   ]
     .filter(Boolean)
     .join(" ");
   const rail = (
-    <aside className="shell__rail shell__rail--default" aria-label={`${sectionLabel} navigation`}>
-      <p className="shell__eyebrow">{sectionLabel}</p>
-      <h1 className="shell__title">{title}</h1>
-      <p className="shell__description">{description}</p>
-      <nav className="shell__nav">
-        <ul className="shell__nav-list">
+    <aside
+      className="shell__rail shell__rail--default relative grid content-start gap-6 border-r border-[color:var(--border-subtle)] px-6 py-6 text-[color:var(--color-text-primary)]"
+      style={shellRailSurfaceStyle}
+      aria-label={`${sectionLabel} navigation`}
+    >
+      <p className="shell__eyebrow mb-3 text-[0.8rem] font-bold uppercase tracking-[0.16em] text-[color:var(--color-text-tertiary)]">
+        {sectionLabel}
+      </p>
+      <h1 className="shell__title m-0 text-[clamp(2rem,3vw,3rem)] leading-[1.05] tracking-[-0.04em]">
+        {title}
+      </h1>
+      <p className="shell__description m-0 max-w-[28ch] text-[color:var(--color-text-secondary)]">
+        {description}
+      </p>
+      <nav className="shell__nav mt-8">
+        <ul className="shell__nav-list m-0 grid list-none gap-3.5 p-0">
           {(navItems ?? []).map((item, index) => (
             <li key={`${item.href}-${index}`} className="shell__nav-item">
-              <Link className="shell__nav-link" href={item.href}>
+              <Link
+                className="shell__nav-link grid gap-[0.15rem] rounded-[var(--radius-md)] border border-[color:var(--border-subtle)] bg-[var(--surface-card)] px-[1.1rem] py-4 no-underline shadow-[var(--shadow-soft)]"
+                href={item.href}
+              >
                 <span>{item.label}</span>
-                <span className="shell__nav-hint">{item.hint}</span>
+                <span className="shell__nav-hint text-[0.9rem] text-[color:var(--color-text-secondary)]">
+                  {item.hint}
+                </span>
               </Link>
             </li>
           ))}
@@ -69,12 +94,20 @@ export function ShellFrameView({
   return (
     <div className={shellClassName} data-sidebar-state={dataSidebarState}>
       {resolvedSidebar}
-      <div className={contentClassName}>
+      <div
+        className={[
+          contentClassName,
+          "grid gap-6 px-6 py-6",
+          topNav == null ? "grid-rows-[auto_1fr]" : "grid-rows-[auto_auto_1fr]",
+        ].join(" ")}
+      >
         {topNav == null ? null : topNav}
         <header className="shell__header">
           <div className="shell__header-intro">
-            <span className="shell__eyebrow">Next.js App Router foundation</span>
-            <p className="shell__header-copy">
+            <span className="shell__eyebrow mb-3 block text-[0.8rem] font-bold uppercase tracking-[0.16em] text-[color:var(--color-text-tertiary)]">
+              Next.js App Router foundation
+            </span>
+            <p className="shell__header-copy text-[color:var(--color-text-secondary)]">
               Route/layout architecture is live. Feature stories still need to
               layer in auth, navigation behavior, data fetching, and final UI.
             </p>

--- a/apps/web/src/components/shell/shell-frame-view.tsx
+++ b/apps/web/src/components/shell/shell-frame-view.tsx
@@ -105,11 +105,10 @@ export function ShellFrameView({
         <header className="shell__header">
           <div className="shell__header-intro">
             <span className="shell__eyebrow mb-3 block text-[0.8rem] font-bold uppercase tracking-[0.16em] text-[color:var(--color-text-tertiary)]">
-              Next.js App Router foundation
+              {sectionLabel}
             </span>
             <p className="shell__header-copy text-[color:var(--color-text-secondary)]">
-              Route/layout architecture is live. Feature stories still need to
-              layer in auth, navigation behavior, data fetching, and final UI.
+              {description}
             </p>
           </div>
           {headerAction == null ? null : (

--- a/apps/web/src/components/shell/top-nav-bar.tsx
+++ b/apps/web/src/components/shell/top-nav-bar.tsx
@@ -25,7 +25,6 @@ const topNavSurfaceStyle = {
   )`,
   boxShadow: "var(--shadow-elevated)",
   backdropFilter: "blur(18px)",
-  gridTemplateAreas: `"brand workspace search actions"`,
 } satisfies React.CSSProperties;
 
 export function TopNavBar({
@@ -82,7 +81,7 @@ export function TopNavBar({
       <TopNavCommandPalette initialOpen={commandPaletteInitialOpen} />
 
       <div
-        className="top-nav__actions flex items-center justify-end gap-3"
+        className="top-nav__actions flex items-stretch justify-end gap-3"
         style={{ gridArea: "actions" }}
         role="group"
         aria-label="Notification and account controls"

--- a/apps/web/src/components/shell/top-nav-bar.tsx
+++ b/apps/web/src/components/shell/top-nav-bar.tsx
@@ -16,6 +16,18 @@ type TopNavBarProps = {
   userMenu: React.ReactNode;
 };
 
+const topNavSurfaceStyle = {
+  borderColor: `color-mix(in srgb, var(--section-accent, var(--color-accent)) 18%, var(--color-border))`,
+  background: `linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--surface-card) 94%, var(--surface-card-subtle)) 0%,
+    color-mix(in srgb, var(--surface-card-subtle) 86%, var(--section-accent, var(--color-accent))) 100%
+  )`,
+  boxShadow: "var(--shadow-elevated)",
+  backdropFilter: "blur(18px)",
+  gridTemplateAreas: `"brand workspace search actions"`,
+} satisfies React.CSSProperties;
+
 export function TopNavBar({
   commandPaletteInitialOpen = false,
   mobileMenuDescription,
@@ -27,16 +39,23 @@ export function TopNavBar({
   userMenu,
 }: TopNavBarProps) {
   return (
-    <nav className="top-nav" aria-label="Authenticated top navigation">
-      <div className="top-nav__brand-cluster">
-        <div className="top-nav__brand-row">
+    <nav
+      className="top-nav sticky top-4 z-[6] grid grid-cols-[minmax(0,1.1fr)_minmax(14rem,18rem)_minmax(18rem,1fr)_auto] items-center gap-4 rounded-[1.45rem] border px-[1.1rem] py-4"
+      style={topNavSurfaceStyle}
+      aria-label="Authenticated top navigation"
+    >
+      <div className="top-nav__brand-cluster grid min-w-0 gap-[0.45rem]" style={{ gridArea: "brand" }}>
+        <div className="top-nav__brand-row grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
           <MobileMenu
             description={mobileMenuDescription}
             initialOpen={mobileMenuInitialOpen}
             navItems={mobileNavItems}
             title={mobileMenuTitle}
           />
-          <Link className="top-nav__brand" href="/dashboard">
+          <Link
+            className="top-nav__brand grid max-w-fit grid-cols-[auto_minmax(0,1fr)] items-center gap-3 no-underline"
+            href="/dashboard"
+          >
             <span className="top-nav__brand-mark" aria-hidden="true">
               CS
             </span>
@@ -46,20 +65,30 @@ export function TopNavBar({
             </span>
           </Link>
         </div>
-        <p className="top-nav__context-note">
+        <p className="top-nav__context-note m-0 max-w-[40ch] text-[0.9rem] text-[color:var(--color-text-secondary)]">
           Authenticated global shell with collaboration controls staged in place.
         </p>
       </div>
 
-      <div className="top-nav__workspace-slot" role="group" aria-label="Workspace controls">
+      <div
+        className="top-nav__workspace-slot"
+        style={{ gridArea: "workspace" }}
+        role="group"
+        aria-label="Workspace controls"
+      >
         {workspaceSwitcher}
       </div>
 
       <TopNavCommandPalette initialOpen={commandPaletteInitialOpen} />
 
-      <div className="top-nav__actions" role="group" aria-label="Notification and account controls">
+      <div
+        className="top-nav__actions flex items-center justify-end gap-3"
+        style={{ gridArea: "actions" }}
+        role="group"
+        aria-label="Notification and account controls"
+      >
         {notificationBell}
-        <div className="top-nav__user-slot">{userMenu}</div>
+        <div className="top-nav__user-slot min-w-0">{userMenu}</div>
       </div>
     </nav>
   );

--- a/apps/web/src/components/shell/top-nav-command-palette.tsx
+++ b/apps/web/src/components/shell/top-nav-command-palette.tsx
@@ -55,6 +55,16 @@ type TopNavCommandPaletteProps = {
   initialOpen?: boolean;
 };
 
+const topNavSearchTriggerStyle = {
+  borderColor: `color-mix(in srgb, var(--color-border) 82%, var(--section-accent, var(--color-accent)) 18%)`,
+  background: `linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--surface-card) 94%, var(--color-bg-secondary)) 0%,
+    color-mix(in srgb, var(--surface-card-subtle) 88%, var(--section-accent, var(--color-accent))) 100%
+  )`,
+  boxShadow: "var(--shadow-soft)",
+} satisfies React.CSSProperties;
+
 export function TopNavCommandPalette({
   initialOpen = false,
 }: Readonly<TopNavCommandPaletteProps>) {
@@ -146,11 +156,16 @@ export function TopNavCommandPalette({
 
   return (
     <>
-      <div className="top-nav__search top-nav__search--desktop-only" role="search">
+      <div
+        className="top-nav__search top-nav__search--desktop-only block"
+        style={{ gridArea: "search" }}
+        role="search"
+      >
         <button
           ref={triggerRef}
           type="button"
-          className="top-nav__search-trigger"
+          className="top-nav__search-trigger grid min-h-16 w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 rounded-[1.15rem] border px-[0.9rem] py-[0.8rem] text-left"
+          style={topNavSearchTriggerStyle}
           aria-controls={isOpen ? dialogId : undefined}
           aria-expanded={isOpen}
           aria-haspopup="dialog"

--- a/apps/web/src/components/shell/workspace-sidebar.tsx
+++ b/apps/web/src/components/shell/workspace-sidebar.tsx
@@ -73,6 +73,49 @@ type WorkspaceSidebarPresentation = {
   title: string;
 };
 
+const workspaceSidebarRailStyle = {
+  background: `linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--section-accent, var(--color-accent)) 12%, var(--surface-card-subtle)) 0%,
+    color-mix(in srgb, var(--section-accent, var(--color-accent)) 4%, var(--surface-card)) 100%
+  )`,
+} satisfies React.CSSProperties;
+
+const workspaceSidebarIdentityMarkStyle = {
+  background: `linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--section-accent, var(--color-accent)) 78%, white),
+    color-mix(in srgb, var(--section-accent, var(--color-accent)) 24%, transparent)
+  )`,
+} satisfies React.CSSProperties;
+
+const workspaceSidebarRoleBadgeStyle = {
+  background: `color-mix(in srgb, var(--section-accent, var(--color-accent)) 14%, var(--surface-card))`,
+} satisfies React.CSSProperties;
+
+const workspaceSidebarLockedStyle = {
+  borderColor: `color-mix(in srgb, var(--color-border) 82%, var(--section-accent, var(--color-accent)) 18%)`,
+  background: `color-mix(in srgb, var(--section-accent, var(--color-accent)) 4%, var(--surface-card))`,
+} satisfies React.CSSProperties;
+
+const workspaceSidebarLockedRestrictedStyle = {
+  borderColor: `color-mix(in srgb, var(--color-warning) 28%, var(--border-subtle))`,
+  background: `color-mix(in srgb, var(--color-warning) 7%, var(--surface-card))`,
+} satisfies React.CSSProperties;
+
+const workspaceSidebarLinkMarkStyle = {
+  background: `linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--section-accent, var(--color-accent)) 20%, var(--surface-card)),
+    color-mix(in srgb, var(--surface-card-subtle) 92%, var(--surface-card))
+  )`,
+  boxShadow: `inset 0 0 0 1px color-mix(in srgb, var(--color-border) 62%, transparent)`,
+} satisfies React.CSSProperties;
+
+const workspaceSidebarGateTagStyle = {
+  background: `color-mix(in srgb, var(--section-accent, var(--color-accent)) 12%, var(--surface-card))`,
+} satisfies React.CSSProperties;
+
 const getWorkspaceSidebarSections = (workspaceId: string) =>
   [
     {
@@ -264,11 +307,19 @@ function WorkspaceSidebarStatus({
   status,
 }: Readonly<{ status: WorkspaceSidebarStatusState }>) {
   return (
-    <div className="workspace-sidebar__status" role="status" aria-live="polite">
-      <strong className="workspace-sidebar__status-title">{status.title}</strong>
-      <p className="workspace-sidebar__status-copy">{status.copy}</p>
+    <div
+      className="workspace-sidebar__status grid gap-1.5 rounded-[1rem] border border-[color:var(--border-subtle)] bg-[var(--surface-card)] px-4 py-[0.95rem]"
+      role="status"
+      aria-live="polite"
+    >
+      <strong className="workspace-sidebar__status-title m-0">{status.title}</strong>
+      <p className="workspace-sidebar__status-copy m-0 text-[0.88rem] text-[color:var(--color-text-secondary)]">
+        {status.copy}
+      </p>
       {status.requestId ? (
-        <p className="workspace-sidebar__status-meta">Request ID: {status.requestId}</p>
+        <p className="workspace-sidebar__status-meta m-0 text-[0.88rem] text-[color:var(--color-text-secondary)]">
+          Request ID: {status.requestId}
+        </p>
       ) : null}
     </div>
   );
@@ -287,20 +338,33 @@ function WorkspaceSidebarLinkContent({
 }>) {
   if (gateLabel) {
     return (
-      <span className="workspace-sidebar__link-copy">
-        <span className="workspace-sidebar__link-label-row">
-          <span className="workspace-sidebar__link-label">{label}</span>
-          <span className="workspace-sidebar__gate-tag">{gateLabel}</span>
+      <span className="workspace-sidebar__link-copy grid min-w-0 gap-[0.18rem]">
+        <span className="workspace-sidebar__link-label-row flex min-w-0 items-center gap-2">
+          <span className="workspace-sidebar__link-label font-bold text-[color:var(--color-text-primary)]">
+            {label}
+          </span>
+          <span
+            className="workspace-sidebar__gate-tag inline-flex items-center justify-center rounded-full px-2 py-[0.2rem] text-[0.74rem] font-bold whitespace-nowrap text-[color:var(--color-text-secondary)]"
+            style={workspaceSidebarGateTagStyle}
+          >
+            {gateLabel}
+          </span>
         </span>
-        <span className="workspace-sidebar__link-description">{meta}</span>
+        <span className="workspace-sidebar__link-description text-[0.88rem] text-[color:var(--color-text-secondary)]">
+          {meta}
+        </span>
       </span>
     );
   }
 
   return (
-    <span className="workspace-sidebar__link-copy">
-      <span className="workspace-sidebar__link-label">{label}</span>
-      <span className="workspace-sidebar__link-description">{description}</span>
+    <span className="workspace-sidebar__link-copy grid min-w-0 gap-[0.18rem]">
+      <span className="workspace-sidebar__link-label font-bold text-[color:var(--color-text-primary)]">
+        {label}
+      </span>
+      <span className="workspace-sidebar__link-description text-[0.88rem] text-[color:var(--color-text-secondary)]">
+        {description}
+      </span>
     </span>
   );
 }
@@ -326,14 +390,18 @@ function WorkspaceSidebarItemRow({
     return (
       <li className="shell__nav-item">
         <Link
-          className="shell__nav-link workspace-sidebar__link"
+          className="shell__nav-link workspace-sidebar__link grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-[var(--radius-md)] border border-[color:var(--border-subtle)] bg-[var(--surface-card)] px-[1.1rem] py-4 no-underline shadow-[var(--shadow-soft)]"
           data-active={itemState.isActive}
           aria-current={itemState.isActive ? "page" : undefined}
           aria-label={collapsed ? item.label : undefined}
           href={item.href}
           title={collapsed ? item.label : undefined}
         >
-          <span className="workspace-sidebar__link-mark" aria-hidden="true">
+          <span
+            className="workspace-sidebar__link-mark inline-grid min-h-10 w-10 place-items-center rounded-[0.9rem] text-[0.76rem] font-extrabold tracking-[0.08em] text-[color:var(--color-text-secondary)]"
+            style={workspaceSidebarLinkMarkStyle}
+            aria-hidden="true"
+          >
             {item.mark}
           </span>
           <WorkspaceSidebarLinkContent
@@ -352,12 +420,17 @@ function WorkspaceSidebarItemRow({
   return (
     <li className="shell__nav-item">
       <div
-        className="workspace-sidebar__locked"
+        className="workspace-sidebar__locked grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-[var(--radius-md)] border border-dashed px-[1.1rem] py-4"
         data-locked={!itemState.hasAccess}
         aria-label={ariaLabel}
         title={collapsed ? ariaLabel : undefined}
+        style={itemState.hasAccess ? workspaceSidebarLockedStyle : workspaceSidebarLockedRestrictedStyle}
       >
-        <span className="workspace-sidebar__link-mark" aria-hidden="true">
+        <span
+          className="workspace-sidebar__link-mark inline-grid min-h-10 w-10 place-items-center rounded-[0.9rem] text-[0.76rem] font-extrabold tracking-[0.08em] text-[color:var(--color-text-secondary)]"
+          style={workspaceSidebarLinkMarkStyle}
+          aria-hidden="true"
+        >
           {itemState.hasAccess ? item.mark : "🔒"}
         </span>
         <WorkspaceSidebarLinkContent
@@ -381,13 +454,16 @@ function WorkspaceSidebarSection({
 }: Readonly<WorkspaceSidebarSectionProps>) {
   return (
     <section
-      className="workspace-sidebar__section"
+      className="workspace-sidebar__section grid gap-[0.7rem]"
       aria-labelledby={`workspace-sidebar-${sectionId}`}
     >
-      <p id={`workspace-sidebar-${sectionId}`} className="workspace-sidebar__section-label">
+      <p
+        id={`workspace-sidebar-${sectionId}`}
+        className="workspace-sidebar__section-label m-0 text-[0.76rem] font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-tertiary)]"
+      >
         {label}
       </p>
-      <ul className="shell__nav-list workspace-sidebar__list">
+      <ul className="shell__nav-list workspace-sidebar__list m-0 grid list-none gap-3 p-0">
         {items.map((item) => (
           <WorkspaceSidebarItemRow
             key={item.href}
@@ -418,7 +494,8 @@ export function WorkspaceSidebarView({
   return (
     <aside
       id={effectiveSidebarId}
-      className="shell__rail workspace-sidebar"
+      className="shell__rail workspace-sidebar relative grid content-start gap-[1.35rem] border-r border-[color:var(--border-subtle)] px-6 py-6 text-[color:var(--color-text-primary)]"
+      style={workspaceSidebarRailStyle}
       aria-label="Workspace navigation"
       data-collapsed={collapsed}
     >
@@ -435,9 +512,9 @@ export function WorkspaceSidebarView({
           <span aria-hidden="true">{collapsed ? ">" : "<"}</span>
         </button>
       ) : null}
-      <div className="workspace-sidebar__header">
+      <div className="workspace-sidebar__header grid gap-4">
         <Link
-          className="workspace-sidebar__back-link"
+          className="workspace-sidebar__back-link inline-flex w-fit items-center gap-[0.45rem] rounded-full bg-[color:color-mix(in_srgb,var(--section-accent,var(--color-accent))_7%,var(--surface-card))] px-[0.7rem] py-[0.45rem] no-underline text-[color:var(--color-text-secondary)]"
           aria-label={collapsed ? "Back to dashboard" : undefined}
           href="/dashboard"
           title={collapsed ? "Back to dashboard" : undefined}
@@ -445,16 +522,27 @@ export function WorkspaceSidebarView({
           <span aria-hidden="true">←</span>
           <span>Back to dashboard</span>
         </Link>
-        <div className="workspace-sidebar__identity">
-          <span className="workspace-sidebar__identity-mark" aria-hidden="true">
+        <div className="workspace-sidebar__identity grid grid-cols-[auto_minmax(0,1fr)] items-start gap-[0.85rem]">
+          <span
+            className="workspace-sidebar__identity-mark inline-grid h-[2.7rem] w-[2.7rem] place-items-center rounded-[1rem] text-[0.92rem] font-extrabold tracking-[0.08em] text-[color:var(--color-bg-primary)]"
+            style={workspaceSidebarIdentityMarkStyle}
+            aria-hidden="true"
+          >
             {presentation.mark}
           </span>
-          <div className="workspace-sidebar__identity-copy">
-            <p className="workspace-sidebar__title">{presentation.title}</p>
-            <p className="workspace-sidebar__description">{presentation.description}</p>
+          <div className="workspace-sidebar__identity-copy grid min-w-0 gap-1">
+            <p className="workspace-sidebar__title m-0 text-[1.15rem] font-extrabold text-[color:var(--color-text-primary)]">
+              {presentation.title}
+            </p>
+            <p className="workspace-sidebar__description m-0 text-[0.9rem] text-[color:var(--color-text-secondary)]">
+              {presentation.description}
+            </p>
           </div>
           {presentation.roleLabel ? (
-            <span className="workspace-sidebar__role-badge">
+            <span
+              className="workspace-sidebar__role-badge ml-[3.55rem] inline-flex justify-self-start rounded-full px-[0.6rem] py-[0.24rem] text-[0.75rem] font-bold uppercase tracking-[0.08em] text-[color:var(--color-text-secondary)]"
+              style={workspaceSidebarRoleBadgeStyle}
+            >
               {presentation.roleLabel}
             </span>
           ) : null}
@@ -463,7 +551,7 @@ export function WorkspaceSidebarView({
 
       {presentation.status ? <WorkspaceSidebarStatus status={presentation.status} /> : null}
 
-      <nav className="workspace-sidebar__nav" aria-label="Workspace route groups">
+      <nav className="workspace-sidebar__nav grid gap-4" aria-label="Workspace route groups">
         {sections.map((section) => (
           <WorkspaceSidebarSection
             key={section.label}

--- a/apps/web/src/components/shell/workspace-switcher.tsx
+++ b/apps/web/src/components/shell/workspace-switcher.tsx
@@ -73,6 +73,43 @@ type WorkspaceMenuNavigationKey =
 const createWorkspaceActionKey = "action:create";
 const retryWorkspaceActionKey = "action:retry";
 
+const workspaceSwitcherTriggerStyle = {
+  borderColor: `color-mix(in srgb, var(--color-border) 78%, var(--section-accent, var(--color-accent)) 22%)`,
+  background: `linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--surface-card) 94%, var(--color-bg-secondary)) 0%,
+    color-mix(in srgb, var(--surface-card-subtle) 88%, var(--section-accent, var(--color-accent))) 100%
+  )`,
+  boxShadow: "var(--shadow-soft)",
+} satisfies React.CSSProperties;
+
+const workspaceSwitcherMarkStyle = {
+  background: `linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--section-accent, var(--color-accent)) 80%, white),
+    color-mix(in srgb, var(--section-accent, var(--color-accent)) 24%, transparent)
+  )`,
+  boxShadow: `inset 0 1px 0 color-mix(in srgb, white 30%, transparent), 0 0 0 1px color-mix(in srgb, var(--section-accent, var(--color-accent)) 24%, transparent)`,
+} satisfies React.CSSProperties;
+
+const workspaceSwitcherPanelStyle = {
+  borderColor: `color-mix(in srgb, var(--color-border) 80%, var(--section-accent, var(--color-accent)) 20%)`,
+  background: `linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--surface-card) 96%, var(--color-bg-secondary)) 0%,
+    color-mix(in srgb, var(--surface-card-subtle) 92%, var(--section-accent, var(--color-accent))) 100%
+  )`,
+  boxShadow: "var(--shadow-elevated)",
+} satisfies React.CSSProperties;
+
+const workspaceSwitcherStateStyle = {
+  background: "var(--surface-card)",
+} satisfies React.CSSProperties;
+
+const workspaceSwitcherItemBadgeStyle = {
+  background: `color-mix(in srgb, var(--section-accent, var(--color-accent)) 16%, var(--surface-card))`,
+} satisfies React.CSSProperties;
+
 const workspaceMenuNavigationKeys = new Set<WorkspaceMenuNavigationKey>([
   "ArrowDown",
   "ArrowUp",
@@ -336,13 +373,16 @@ const getWorkspaceSwitcherActions = (
 };
 
 const LoadingWorkspaceSkeleton = () => (
-  <div className="workspace-switcher__skeleton-list" aria-hidden="true">
+  <div className="workspace-switcher__skeleton-list grid gap-[0.7rem]" aria-hidden="true">
     {Array.from({ length: 3 }, (_, index) => (
-      <div key={`workspace-skeleton-${index}`} className="workspace-switcher__skeleton-row">
-        <span className="workspace-switcher__skeleton-mark" />
-        <span className="workspace-switcher__skeleton-copy">
-          <span className="workspace-switcher__skeleton-line workspace-switcher__skeleton-line--primary" />
-          <span className="workspace-switcher__skeleton-line workspace-switcher__skeleton-line--secondary" />
+      <div
+        key={`workspace-skeleton-${index}`}
+        className="workspace-switcher__skeleton-row grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
+      >
+        <span className="workspace-switcher__skeleton-mark h-[2.45rem] w-[2.45rem] rounded-full bg-[var(--surface-card-muted)]" />
+        <span className="workspace-switcher__skeleton-copy grid gap-[0.35rem]">
+          <span className="workspace-switcher__skeleton-line workspace-switcher__skeleton-line--primary block h-[0.7rem] w-[58%] rounded-full bg-[var(--surface-card-muted)]" />
+          <span className="workspace-switcher__skeleton-line workspace-switcher__skeleton-line--secondary block h-[0.7rem] w-[76%] rounded-full bg-[var(--surface-card-muted)]" />
         </span>
       </div>
     ))}
@@ -416,13 +456,14 @@ export function WorkspaceSwitcherMenu({
 
   return (
     <DropdownMenu modal={false} open={isOpen} onOpenChange={setIsOpen}>
-      <div className="workspace-switcher">
+      <div className="workspace-switcher relative">
         <DropdownMenuTrigger asChild>
           <button
             ref={triggerRef}
             id={`${menuId}-trigger`}
             type="button"
-            className="workspace-switcher__trigger"
+            className="workspace-switcher__trigger grid min-h-16 w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 rounded-[1.15rem] border px-[0.9rem] py-[0.8rem] text-left"
+            style={workspaceSwitcherTriggerStyle}
             aria-expanded={isOpen}
             aria-haspopup="menu"
             aria-controls={menuId}
@@ -443,14 +484,25 @@ export function WorkspaceSwitcherMenu({
               openMenu(getWorkspaceMenuOpenIndex(event.key, currentWorkspaceIndex, actions.length));
             }}
           >
-            <span className="workspace-switcher__trigger-mark" aria-hidden="true">
+            <span
+              className="workspace-switcher__trigger-mark inline-grid h-[2.45rem] w-[2.45rem] place-items-center rounded-full text-[0.84rem] font-extrabold tracking-[0.06em] text-[color:var(--color-bg-primary)]"
+              style={workspaceSwitcherMarkStyle}
+              aria-hidden="true"
+            >
               {triggerCopy.icon}
             </span>
-            <span className="workspace-switcher__trigger-copy">
-              <span className="workspace-switcher__trigger-label">{triggerCopy.label}</span>
-              <span className="workspace-switcher__trigger-meta">{triggerCopy.meta}</span>
+            <span className="workspace-switcher__trigger-copy grid min-w-0 gap-[0.16rem]">
+              <span className="workspace-switcher__trigger-label text-[0.98rem] font-bold text-[color:var(--color-text-primary)]">
+                {triggerCopy.label}
+              </span>
+              <span className="workspace-switcher__trigger-meta text-[0.86rem] text-[color:var(--color-text-secondary)]">
+                {triggerCopy.meta}
+              </span>
             </span>
-            <span className="workspace-switcher__trigger-caret" aria-hidden="true">
+            <span
+              className="workspace-switcher__trigger-caret text-[0.88rem] text-[color:var(--color-text-tertiary)]"
+              aria-hidden="true"
+            >
               {isOpen ? "▴" : "▾"}
             </span>
           </button>
@@ -459,7 +511,8 @@ export function WorkspaceSwitcherMenu({
         {isOpen ? (
           <DropdownMenuContent
             id={menuId}
-            className="workspace-switcher__panel"
+            className="workspace-switcher__panel z-[8] max-h-[min(32rem,calc(100vh-6rem))] w-[min(28rem,calc(100vw-3rem))] overflow-y-auto rounded-[1.35rem] border p-4"
+            style={workspaceSwitcherPanelStyle}
             align="start"
             sideOffset={12}
             onCloseAutoFocus={(event) => {
@@ -467,32 +520,40 @@ export function WorkspaceSwitcherMenu({
               triggerRef.current?.focus();
             }}
           >
-            <div className="workspace-switcher__panel-header">
-              <p className="workspace-switcher__panel-eyebrow">Workspace switcher</p>
-              <p className="workspace-switcher__panel-title">
+            <div className="workspace-switcher__panel-header mb-[0.85rem] grid gap-[0.28rem]">
+              <p className="workspace-switcher__panel-eyebrow m-0 text-[0.76rem] font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-tertiary)]">
+                Workspace switcher
+              </p>
+              <p className="workspace-switcher__panel-title m-0 text-[0.98rem] font-bold text-[color:var(--color-text-primary)]">
                 {currentWorkspaceId ? "Switch workspace context" : "Select Workspace"}
               </p>
             </div>
 
             {dataState.kind === "loading" ? (
               <div
-                className="workspace-switcher__state workspace-switcher__state--loading"
+                className="workspace-switcher__state workspace-switcher__state--loading mb-[0.85rem] grid gap-2 rounded-[1rem] border border-[color:var(--border-subtle)] px-4 py-[0.95rem]"
+                style={workspaceSwitcherStateStyle}
                 role="status"
                 aria-live="polite"
               >
                 <LoadingWorkspaceSkeleton />
-                <p className="workspace-switcher__state-copy">Loading member workspaces.</p>
+                <p className="workspace-switcher__state-copy m-0 text-[0.86rem] text-[color:var(--color-text-secondary)]">
+                  Loading member workspaces.
+                </p>
               </div>
             ) : null}
 
             {dataState.kind === "empty" ? (
               <div
-                className="workspace-switcher__state workspace-switcher__state--empty"
+                className="workspace-switcher__state workspace-switcher__state--empty mb-[0.85rem] grid gap-2 rounded-[1rem] border border-[color:var(--border-subtle)] px-4 py-[0.95rem]"
+                style={workspaceSwitcherStateStyle}
                 role="status"
                 aria-live="polite"
               >
-                <strong className="workspace-switcher__state-title">No workspaces yet</strong>
-                <p className="workspace-switcher__state-copy">
+                <strong className="workspace-switcher__state-title m-0 text-[0.98rem] font-bold text-[color:var(--color-text-primary)]">
+                  No workspaces yet
+                </strong>
+                <p className="workspace-switcher__state-copy m-0 text-[0.86rem] text-[color:var(--color-text-secondary)]">
                   Create your first workspace or join one through an invitation.
                 </p>
               </div>
@@ -500,19 +561,26 @@ export function WorkspaceSwitcherMenu({
 
             {dataState.kind === "error" ? (
               <div
-                className="workspace-switcher__state workspace-switcher__state--error"
+                className="workspace-switcher__state workspace-switcher__state--error mb-[0.85rem] grid gap-2 rounded-[1rem] border border-[color:var(--border-subtle)] px-4 py-[0.95rem]"
+                style={workspaceSwitcherStateStyle}
                 role="status"
                 aria-live="polite"
               >
-                <strong className="workspace-switcher__state-title">Workspace list unavailable</strong>
-                <p className="workspace-switcher__state-copy">{dataState.message}</p>
+                <strong className="workspace-switcher__state-title m-0 text-[0.98rem] font-bold text-[color:var(--color-text-primary)]">
+                  Workspace list unavailable
+                </strong>
+                <p className="workspace-switcher__state-copy m-0 text-[0.86rem] text-[color:var(--color-text-secondary)]">
+                  {dataState.message}
+                </p>
                 {dataState.requestId ? (
-                  <p className="workspace-switcher__state-meta">Request ID: {dataState.requestId}</p>
+                  <p className="workspace-switcher__state-meta m-0 text-[0.86rem] text-[color:var(--color-text-secondary)]">
+                    Request ID: {dataState.requestId}
+                  </p>
                 ) : null}
               </div>
             ) : null}
 
-            <DropdownMenuGroup className="workspace-switcher__menu">
+            <DropdownMenuGroup className="workspace-switcher__menu grid gap-[0.55rem]">
               {actions.map((action, index) => {
                 const isCurrent = action.kind === "workspace" && action.current;
 
@@ -522,7 +590,7 @@ export function WorkspaceSwitcherMenu({
                     ref={(node) => {
                       itemRefs.current[index] = node;
                     }}
-                    className="workspace-switcher__item"
+                    className="workspace-switcher__item grid w-full grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-[1rem] border border-[color:var(--border-subtle)] bg-[var(--surface-card)] px-[0.95rem] py-[0.9rem] text-left"
                     data-current={isCurrent || undefined}
                     aria-current={isCurrent ? "page" : undefined}
                     aria-label={
@@ -537,29 +605,48 @@ export function WorkspaceSwitcherMenu({
                   >
                     {action.kind === "workspace" ? (
                       <>
-                        <span className="workspace-switcher__item-mark" aria-hidden="true">
+                        <span
+                          className="workspace-switcher__item-mark inline-grid h-[2.45rem] w-[2.45rem] place-items-center rounded-full text-[0.84rem] font-extrabold tracking-[0.06em] text-[color:var(--color-bg-primary)]"
+                          style={workspaceSwitcherMarkStyle}
+                          aria-hidden="true"
+                        >
                           {getWorkspaceInitials(action.workspace)}
                         </span>
-                        <span className="workspace-switcher__item-copy">
-                          <span className="workspace-switcher__item-label-row">
-                            <span className="workspace-switcher__item-label">{action.workspace.name}</span>
+                        <span className="workspace-switcher__item-copy grid min-w-0 gap-[0.16rem]">
+                          <span className="workspace-switcher__item-label-row flex min-w-0 items-center gap-[0.55rem]">
+                            <span className="workspace-switcher__item-label text-[0.98rem] font-bold text-[color:var(--color-text-primary)]">
+                              {action.workspace.name}
+                            </span>
                             {action.current ? (
-                              <span className="workspace-switcher__item-badge">Current</span>
+                              <span
+                                className="workspace-switcher__item-badge rounded-full px-[0.48rem] py-[0.18rem] text-[0.74rem] font-bold whitespace-nowrap text-[color:var(--color-text-secondary)]"
+                                style={workspaceSwitcherItemBadgeStyle}
+                              >
+                                Current
+                              </span>
                             ) : null}
                           </span>
-                          <span className="workspace-switcher__item-description">
+                          <span className="workspace-switcher__item-description text-[0.86rem] text-[color:var(--color-text-secondary)]">
                             {getWorkspaceMeta(action.workspace)}
                           </span>
                         </span>
                       </>
                     ) : (
                       <>
-                        <span className="workspace-switcher__item-mark" aria-hidden="true">
+                        <span
+                          className="workspace-switcher__item-mark inline-grid h-[2.45rem] w-[2.45rem] place-items-center rounded-full text-[0.84rem] font-extrabold tracking-[0.06em] text-[color:var(--color-bg-primary)]"
+                          style={workspaceSwitcherMarkStyle}
+                          aria-hidden="true"
+                        >
                           {action.kind === "retry" ? "↺" : "+"}
                         </span>
-                        <span className="workspace-switcher__item-copy">
-                          <span className="workspace-switcher__item-label">{action.label}</span>
-                          <span className="workspace-switcher__item-description">{action.description}</span>
+                        <span className="workspace-switcher__item-copy grid min-w-0 gap-[0.16rem]">
+                          <span className="workspace-switcher__item-label text-[0.98rem] font-bold text-[color:var(--color-text-primary)]">
+                            {action.label}
+                          </span>
+                          <span className="workspace-switcher__item-description text-[0.86rem] text-[color:var(--color-text-secondary)]">
+                            {action.description}
+                          </span>
                         </span>
                       </>
                     )}

--- a/apps/web/src/components/shell/workspace-switcher.tsx
+++ b/apps/web/src/components/shell/workspace-switcher.tsx
@@ -389,6 +389,229 @@ const LoadingWorkspaceSkeleton = () => (
   </div>
 );
 
+type WorkspaceSwitcherTriggerProps = {
+  actionsLength: number;
+  currentWorkspaceIndex: number;
+  isOpen: boolean;
+  menuId: string;
+  onCloseMenu: (restoreFocus?: boolean) => void;
+  onOpenMenu: (nextIndex?: number) => void;
+  triggerCopy: ReturnType<typeof getWorkspaceTriggerCopy>;
+  triggerRef: React.RefObject<HTMLButtonElement | null>;
+};
+
+const WorkspaceSwitcherTrigger = ({
+  actionsLength,
+  currentWorkspaceIndex,
+  isOpen,
+  menuId,
+  onCloseMenu,
+  onOpenMenu,
+  triggerCopy,
+  triggerRef,
+}: Readonly<WorkspaceSwitcherTriggerProps>) => (
+  <DropdownMenuTrigger asChild>
+    <button
+      ref={triggerRef}
+      id={`${menuId}-trigger`}
+      type="button"
+      className="workspace-switcher__trigger grid min-h-16 w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 rounded-[1.15rem] border px-[0.9rem] py-[0.8rem] text-left"
+      style={workspaceSwitcherTriggerStyle}
+      aria-expanded={isOpen}
+      aria-haspopup="menu"
+      aria-controls={menuId}
+      onClick={() => {
+        if (isOpen) {
+          onCloseMenu(true);
+          return;
+        }
+
+        onOpenMenu(getDefaultActiveIndex(currentWorkspaceIndex));
+      }}
+      onKeyDown={(event: ReactKeyboardEvent<HTMLButtonElement>) => {
+        if (!isWorkspaceMenuOpenKey(event.key)) {
+          return;
+        }
+
+        event.preventDefault();
+        onOpenMenu(getWorkspaceMenuOpenIndex(event.key, currentWorkspaceIndex, actionsLength));
+      }}
+    >
+      <span
+        className="workspace-switcher__trigger-mark inline-grid h-[2.45rem] w-[2.45rem] place-items-center rounded-full text-[0.84rem] font-extrabold tracking-[0.06em] text-[color:var(--color-bg-primary)]"
+        style={workspaceSwitcherMarkStyle}
+        aria-hidden="true"
+      >
+        {triggerCopy.icon}
+      </span>
+      <span className="workspace-switcher__trigger-copy grid min-w-0 gap-[0.16rem]">
+        <span className="workspace-switcher__trigger-label text-[0.98rem] font-bold text-[color:var(--color-text-primary)]">
+          {triggerCopy.label}
+        </span>
+        <span className="workspace-switcher__trigger-meta text-[0.86rem] text-[color:var(--color-text-secondary)]">
+          {triggerCopy.meta}
+        </span>
+      </span>
+      <span
+        className="workspace-switcher__trigger-caret text-[0.88rem] text-[color:var(--color-text-tertiary)]"
+        aria-hidden="true"
+      >
+        {isOpen ? "▴" : "▾"}
+      </span>
+    </button>
+  </DropdownMenuTrigger>
+);
+
+type WorkspaceSwitcherStatePanelProps = {
+  dataState: WorkspaceSwitcherDataState;
+};
+
+const WorkspaceSwitcherStatePanel = ({ dataState }: Readonly<WorkspaceSwitcherStatePanelProps>) => {
+  if (dataState.kind === "loading") {
+    return (
+      <div
+        className="workspace-switcher__state workspace-switcher__state--loading mb-[0.85rem] grid gap-2 rounded-[1rem] border border-[color:var(--border-subtle)] px-4 py-[0.95rem]"
+        style={workspaceSwitcherStateStyle}
+        role="status"
+        aria-live="polite"
+      >
+        <LoadingWorkspaceSkeleton />
+        <p className="workspace-switcher__state-copy m-0 text-[0.86rem] text-[color:var(--color-text-secondary)]">
+          Loading member workspaces.
+        </p>
+      </div>
+    );
+  }
+
+  if (dataState.kind === "empty") {
+    return (
+      <div
+        className="workspace-switcher__state workspace-switcher__state--empty mb-[0.85rem] grid gap-2 rounded-[1rem] border border-[color:var(--border-subtle)] px-4 py-[0.95rem]"
+        style={workspaceSwitcherStateStyle}
+        role="status"
+        aria-live="polite"
+      >
+        <strong className="workspace-switcher__state-title m-0 text-[0.98rem] font-bold text-[color:var(--color-text-primary)]">
+          No workspaces yet
+        </strong>
+        <p className="workspace-switcher__state-copy m-0 text-[0.86rem] text-[color:var(--color-text-secondary)]">
+          Create your first workspace or join one through an invitation.
+        </p>
+      </div>
+    );
+  }
+
+  if (dataState.kind === "error") {
+    return (
+      <div
+        className="workspace-switcher__state workspace-switcher__state--error mb-[0.85rem] grid gap-2 rounded-[1rem] border border-[color:var(--border-subtle)] px-4 py-[0.95rem]"
+        style={workspaceSwitcherStateStyle}
+        role="status"
+        aria-live="polite"
+      >
+        <strong className="workspace-switcher__state-title m-0 text-[0.98rem] font-bold text-[color:var(--color-text-primary)]">
+          Workspace list unavailable
+        </strong>
+        <p className="workspace-switcher__state-copy m-0 text-[0.86rem] text-[color:var(--color-text-secondary)]">
+          {dataState.message}
+        </p>
+        {dataState.requestId ? (
+          <p className="workspace-switcher__state-meta m-0 text-[0.86rem] text-[color:var(--color-text-secondary)]">
+            Request ID: {dataState.requestId}
+          </p>
+        ) : null}
+      </div>
+    );
+  }
+
+  return null;
+};
+
+type WorkspaceSwitcherMenuItemProps = {
+  action: WorkspaceSwitcherAction;
+  index: number;
+  itemRefs: React.MutableRefObject<Array<HTMLElement | null>>;
+  onSelectAction: (action: WorkspaceSwitcherAction) => void;
+};
+
+const WorkspaceSwitcherMenuItem = ({
+  action,
+  index,
+  itemRefs,
+  onSelectAction,
+}: Readonly<WorkspaceSwitcherMenuItemProps>) => {
+  const isCurrent = action.kind === "workspace" && action.current;
+  const icon = action.kind === "retry" ? "↺" : "+";
+
+  return (
+    <DropdownMenuItem
+      ref={(node) => {
+        itemRefs.current[index] = node;
+      }}
+      className="workspace-switcher__item grid w-full grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-[1rem] border border-[color:var(--border-subtle)] bg-[var(--surface-card)] px-[0.95rem] py-[0.9rem] text-left"
+      data-current={isCurrent || undefined}
+      aria-current={isCurrent ? "page" : undefined}
+      aria-label={
+        action.kind === "workspace" && action.current
+          ? `${action.workspace.name}, current workspace`
+          : undefined
+      }
+      onSelect={(event) => {
+        event.preventDefault();
+        onSelectAction(action);
+      }}
+    >
+      {action.kind === "workspace" ? (
+        <>
+          <span
+            className="workspace-switcher__item-mark inline-grid h-[2.45rem] w-[2.45rem] place-items-center rounded-full text-[0.84rem] font-extrabold tracking-[0.06em] text-[color:var(--color-bg-primary)]"
+            style={workspaceSwitcherMarkStyle}
+            aria-hidden="true"
+          >
+            {getWorkspaceInitials(action.workspace)}
+          </span>
+          <span className="workspace-switcher__item-copy grid min-w-0 gap-[0.16rem]">
+            <span className="workspace-switcher__item-label-row flex min-w-0 items-center gap-[0.55rem]">
+              <span className="workspace-switcher__item-label text-[0.98rem] font-bold text-[color:var(--color-text-primary)]">
+                {action.workspace.name}
+              </span>
+              {action.current ? (
+                <span
+                  className="workspace-switcher__item-badge rounded-full px-[0.48rem] py-[0.18rem] text-[0.74rem] font-bold whitespace-nowrap text-[color:var(--color-text-secondary)]"
+                  style={workspaceSwitcherItemBadgeStyle}
+                >
+                  Current
+                </span>
+              ) : null}
+            </span>
+            <span className="workspace-switcher__item-description text-[0.86rem] text-[color:var(--color-text-secondary)]">
+              {getWorkspaceMeta(action.workspace)}
+            </span>
+          </span>
+        </>
+      ) : (
+        <>
+          <span
+            className="workspace-switcher__item-mark inline-grid h-[2.45rem] w-[2.45rem] place-items-center rounded-full text-[0.84rem] font-extrabold tracking-[0.06em] text-[color:var(--color-bg-primary)]"
+            style={workspaceSwitcherMarkStyle}
+            aria-hidden="true"
+          >
+            {icon}
+          </span>
+          <span className="workspace-switcher__item-copy grid min-w-0 gap-[0.16rem]">
+            <span className="workspace-switcher__item-label text-[0.98rem] font-bold text-[color:var(--color-text-primary)]">
+              {action.label}
+            </span>
+            <span className="workspace-switcher__item-description text-[0.86rem] text-[color:var(--color-text-secondary)]">
+              {action.description}
+            </span>
+          </span>
+        </>
+      )}
+    </DropdownMenuItem>
+  );
+};
+
 export function WorkspaceSwitcherMenu({
   currentWorkspaceId,
   dataState,
@@ -457,56 +680,16 @@ export function WorkspaceSwitcherMenu({
   return (
     <DropdownMenu modal={false} open={isOpen} onOpenChange={setIsOpen}>
       <div className="workspace-switcher relative">
-        <DropdownMenuTrigger asChild>
-          <button
-            ref={triggerRef}
-            id={`${menuId}-trigger`}
-            type="button"
-            className="workspace-switcher__trigger grid min-h-16 w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 rounded-[1.15rem] border px-[0.9rem] py-[0.8rem] text-left"
-            style={workspaceSwitcherTriggerStyle}
-            aria-expanded={isOpen}
-            aria-haspopup="menu"
-            aria-controls={menuId}
-            onClick={() => {
-              if (isOpen) {
-                closeMenu(true);
-                return;
-              }
-
-              openMenu(getDefaultActiveIndex(currentWorkspaceIndex));
-            }}
-            onKeyDown={(event: ReactKeyboardEvent<HTMLButtonElement>) => {
-              if (!isWorkspaceMenuOpenKey(event.key)) {
-                return;
-              }
-
-              event.preventDefault();
-              openMenu(getWorkspaceMenuOpenIndex(event.key, currentWorkspaceIndex, actions.length));
-            }}
-          >
-            <span
-              className="workspace-switcher__trigger-mark inline-grid h-[2.45rem] w-[2.45rem] place-items-center rounded-full text-[0.84rem] font-extrabold tracking-[0.06em] text-[color:var(--color-bg-primary)]"
-              style={workspaceSwitcherMarkStyle}
-              aria-hidden="true"
-            >
-              {triggerCopy.icon}
-            </span>
-            <span className="workspace-switcher__trigger-copy grid min-w-0 gap-[0.16rem]">
-              <span className="workspace-switcher__trigger-label text-[0.98rem] font-bold text-[color:var(--color-text-primary)]">
-                {triggerCopy.label}
-              </span>
-              <span className="workspace-switcher__trigger-meta text-[0.86rem] text-[color:var(--color-text-secondary)]">
-                {triggerCopy.meta}
-              </span>
-            </span>
-            <span
-              className="workspace-switcher__trigger-caret text-[0.88rem] text-[color:var(--color-text-tertiary)]"
-              aria-hidden="true"
-            >
-              {isOpen ? "▴" : "▾"}
-            </span>
-          </button>
-        </DropdownMenuTrigger>
+        <WorkspaceSwitcherTrigger
+          actionsLength={actions.length}
+          currentWorkspaceIndex={currentWorkspaceIndex}
+          isOpen={isOpen}
+          menuId={menuId}
+          onCloseMenu={closeMenu}
+          onOpenMenu={openMenu}
+          triggerCopy={triggerCopy}
+          triggerRef={triggerRef}
+        />
 
         {isOpen ? (
           <DropdownMenuContent
@@ -529,130 +712,18 @@ export function WorkspaceSwitcherMenu({
               </p>
             </div>
 
-            {dataState.kind === "loading" ? (
-              <div
-                className="workspace-switcher__state workspace-switcher__state--loading mb-[0.85rem] grid gap-2 rounded-[1rem] border border-[color:var(--border-subtle)] px-4 py-[0.95rem]"
-                style={workspaceSwitcherStateStyle}
-                role="status"
-                aria-live="polite"
-              >
-                <LoadingWorkspaceSkeleton />
-                <p className="workspace-switcher__state-copy m-0 text-[0.86rem] text-[color:var(--color-text-secondary)]">
-                  Loading member workspaces.
-                </p>
-              </div>
-            ) : null}
-
-            {dataState.kind === "empty" ? (
-              <div
-                className="workspace-switcher__state workspace-switcher__state--empty mb-[0.85rem] grid gap-2 rounded-[1rem] border border-[color:var(--border-subtle)] px-4 py-[0.95rem]"
-                style={workspaceSwitcherStateStyle}
-                role="status"
-                aria-live="polite"
-              >
-                <strong className="workspace-switcher__state-title m-0 text-[0.98rem] font-bold text-[color:var(--color-text-primary)]">
-                  No workspaces yet
-                </strong>
-                <p className="workspace-switcher__state-copy m-0 text-[0.86rem] text-[color:var(--color-text-secondary)]">
-                  Create your first workspace or join one through an invitation.
-                </p>
-              </div>
-            ) : null}
-
-            {dataState.kind === "error" ? (
-              <div
-                className="workspace-switcher__state workspace-switcher__state--error mb-[0.85rem] grid gap-2 rounded-[1rem] border border-[color:var(--border-subtle)] px-4 py-[0.95rem]"
-                style={workspaceSwitcherStateStyle}
-                role="status"
-                aria-live="polite"
-              >
-                <strong className="workspace-switcher__state-title m-0 text-[0.98rem] font-bold text-[color:var(--color-text-primary)]">
-                  Workspace list unavailable
-                </strong>
-                <p className="workspace-switcher__state-copy m-0 text-[0.86rem] text-[color:var(--color-text-secondary)]">
-                  {dataState.message}
-                </p>
-                {dataState.requestId ? (
-                  <p className="workspace-switcher__state-meta m-0 text-[0.86rem] text-[color:var(--color-text-secondary)]">
-                    Request ID: {dataState.requestId}
-                  </p>
-                ) : null}
-              </div>
-            ) : null}
+            <WorkspaceSwitcherStatePanel dataState={dataState} />
 
             <DropdownMenuGroup className="workspace-switcher__menu grid gap-[0.55rem]">
-              {actions.map((action, index) => {
-                const isCurrent = action.kind === "workspace" && action.current;
-
-                return (
-                  <DropdownMenuItem
-                    key={action.key}
-                    ref={(node) => {
-                      itemRefs.current[index] = node;
-                    }}
-                    className="workspace-switcher__item grid w-full grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-[1rem] border border-[color:var(--border-subtle)] bg-[var(--surface-card)] px-[0.95rem] py-[0.9rem] text-left"
-                    data-current={isCurrent || undefined}
-                    aria-current={isCurrent ? "page" : undefined}
-                    aria-label={
-                      action.kind === "workspace" && action.current
-                        ? `${action.workspace.name}, current workspace`
-                        : undefined
-                    }
-                    onSelect={(event) => {
-                      event.preventDefault();
-                      handleActionSelect(action);
-                    }}
-                  >
-                    {action.kind === "workspace" ? (
-                      <>
-                        <span
-                          className="workspace-switcher__item-mark inline-grid h-[2.45rem] w-[2.45rem] place-items-center rounded-full text-[0.84rem] font-extrabold tracking-[0.06em] text-[color:var(--color-bg-primary)]"
-                          style={workspaceSwitcherMarkStyle}
-                          aria-hidden="true"
-                        >
-                          {getWorkspaceInitials(action.workspace)}
-                        </span>
-                        <span className="workspace-switcher__item-copy grid min-w-0 gap-[0.16rem]">
-                          <span className="workspace-switcher__item-label-row flex min-w-0 items-center gap-[0.55rem]">
-                            <span className="workspace-switcher__item-label text-[0.98rem] font-bold text-[color:var(--color-text-primary)]">
-                              {action.workspace.name}
-                            </span>
-                            {action.current ? (
-                              <span
-                                className="workspace-switcher__item-badge rounded-full px-[0.48rem] py-[0.18rem] text-[0.74rem] font-bold whitespace-nowrap text-[color:var(--color-text-secondary)]"
-                                style={workspaceSwitcherItemBadgeStyle}
-                              >
-                                Current
-                              </span>
-                            ) : null}
-                          </span>
-                          <span className="workspace-switcher__item-description text-[0.86rem] text-[color:var(--color-text-secondary)]">
-                            {getWorkspaceMeta(action.workspace)}
-                          </span>
-                        </span>
-                      </>
-                    ) : (
-                      <>
-                        <span
-                          className="workspace-switcher__item-mark inline-grid h-[2.45rem] w-[2.45rem] place-items-center rounded-full text-[0.84rem] font-extrabold tracking-[0.06em] text-[color:var(--color-bg-primary)]"
-                          style={workspaceSwitcherMarkStyle}
-                          aria-hidden="true"
-                        >
-                          {action.kind === "retry" ? "↺" : "+"}
-                        </span>
-                        <span className="workspace-switcher__item-copy grid min-w-0 gap-[0.16rem]">
-                          <span className="workspace-switcher__item-label text-[0.98rem] font-bold text-[color:var(--color-text-primary)]">
-                            {action.label}
-                          </span>
-                          <span className="workspace-switcher__item-description text-[0.86rem] text-[color:var(--color-text-secondary)]">
-                            {action.description}
-                          </span>
-                        </span>
-                      </>
-                    )}
-                  </DropdownMenuItem>
-                );
-              })}
+              {actions.map((action, index) => (
+                <WorkspaceSwitcherMenuItem
+                  key={action.key}
+                  action={action}
+                  index={index}
+                  itemRefs={itemRefs}
+                  onSelectAction={handleActionSelect}
+                />
+              ))}
             </DropdownMenuGroup>
           </DropdownMenuContent>
         ) : null}

--- a/tests/unit/web-global-sidebar.test.tsx
+++ b/tests/unit/web-global-sidebar.test.tsx
@@ -60,7 +60,7 @@ test("shell frame can render a custom sidebar in place of the generic rail", () 
     </ShellFrame>,
   );
 
-  assert.match(markup, /class="[^"]*shell__rail[^"]*global-sidebar[^"]*"/);
+  assert.match(markup, /class="(?=[^"]*\bshell__rail\b)(?=[^"]*\bglobal-sidebar\b)[^"]*"/);
   assert.match(markup, /aria-current="page" href="\/dashboard"/);
   assert.doesNotMatch(markup, /Authenticated global context navigation/);
 });
@@ -84,7 +84,10 @@ test("shell frame honors an explicit null sidebar instead of falling back to the
   );
 
   assert.doesNotMatch(markup, /shell__rail--default/);
-  assert.match(markup, /class="[^"]*shell[^"]*shell--global[^"]*shell--no-rail[^"]*"/);
+  assert.match(
+    markup,
+    /class="(?=[^"]*\bshell\b)(?=[^"]*\bshell--global\b)(?=[^"]*\bshell--no-rail\b)[^"]*"/,
+  );
   assert.doesNotMatch(markup, /Authenticated global context navigation/);
 });
 
@@ -107,6 +110,9 @@ test("shell frame keeps the structured default rail layout when no custom sideba
     </ShellFrame>,
   );
 
-  assert.match(markup, /class="[^"]*shell__rail[^"]*shell__rail--default[^"]*"/);
+  assert.match(
+    markup,
+    /class="(?=[^"]*\bshell__rail\b)(?=[^"]*\bshell__rail--default\b)[^"]*"/,
+  );
   assert.doesNotMatch(markup, /shell--no-rail/);
 });

--- a/tests/unit/web-global-sidebar.test.tsx
+++ b/tests/unit/web-global-sidebar.test.tsx
@@ -60,7 +60,7 @@ test("shell frame can render a custom sidebar in place of the generic rail", () 
     </ShellFrame>,
   );
 
-  assert.match(markup, /class="shell__rail global-sidebar"/);
+  assert.match(markup, /class="[^"]*shell__rail[^"]*global-sidebar[^"]*"/);
   assert.match(markup, /aria-current="page" href="\/dashboard"/);
   assert.doesNotMatch(markup, /Authenticated global context navigation/);
 });
@@ -84,7 +84,7 @@ test("shell frame honors an explicit null sidebar instead of falling back to the
   );
 
   assert.doesNotMatch(markup, /shell__rail--default/);
-  assert.match(markup, /class="shell shell--global shell--no-rail"/);
+  assert.match(markup, /class="[^"]*shell[^"]*shell--global[^"]*shell--no-rail[^"]*"/);
   assert.doesNotMatch(markup, /Authenticated global context navigation/);
 });
 
@@ -107,6 +107,6 @@ test("shell frame keeps the structured default rail layout when no custom sideba
     </ShellFrame>,
   );
 
-  assert.match(markup, /class="shell__rail shell__rail--default"/);
+  assert.match(markup, /class="[^"]*shell__rail[^"]*shell__rail--default[^"]*"/);
   assert.doesNotMatch(markup, /shell--no-rail/);
 });

--- a/tests/unit/web-sidebar-state.test.tsx
+++ b/tests/unit/web-sidebar-state.test.tsx
@@ -100,7 +100,7 @@ test("shell frame propagates a collapsed desktop sidebar state into the authenti
   );
 
   assert.match(markup, /data-sidebar-state="collapsed"/);
-  assert.match(markup, /class="shell__rail global-sidebar"/);
+  assert.match(markup, /class="[^"]*shell__rail[^"]*global-sidebar[^"]*"/);
   assert.match(markup, /data-collapsed="true"/);
   assert.match(markup, /aria-label="Expand sidebar"/);
   assert.match(markup, /aria-controls="[^"]+"/);

--- a/tests/unit/web-sidebar-state.test.tsx
+++ b/tests/unit/web-sidebar-state.test.tsx
@@ -100,7 +100,7 @@ test("shell frame propagates a collapsed desktop sidebar state into the authenti
   );
 
   assert.match(markup, /data-sidebar-state="collapsed"/);
-  assert.match(markup, /class="[^"]*shell__rail[^"]*global-sidebar[^"]*"/);
+  assert.match(markup, /class="(?=[^"]*\bshell__rail\b)(?=[^"]*\bglobal-sidebar\b)[^"]*"/);
   assert.match(markup, /data-collapsed="true"/);
   assert.match(markup, /aria-label="Expand sidebar"/);
   assert.match(markup, /aria-controls="[^"]+"/);

--- a/tests/unit/web-theme-token-contract.test.ts
+++ b/tests/unit/web-theme-token-contract.test.ts
@@ -118,25 +118,34 @@ test("globals.css imports the canonical theme/token styles and removes the old a
   assert.ok(globalsCss.includes("var(--color-accent)"));
 });
 
-test("globals.css keeps grid sidebar layout scoped to the concrete sidebar variants", () => {
-  const shellRailRule = getCssBlock(globalsCss, ".shell__rail");
-  const defaultRailRule = getCssBlock(globalsCss, ".shell__rail--default");
-  const globalSidebarRule = getCssBlock(globalsCss, ".global-sidebar");
-  const workspaceSidebarRule = getCssBlock(globalsCss, ".workspace-sidebar");
+test("globals.css preserves shell state selectors while leaving migrated rail layout ownership in components", () => {
+  const shellRailRule = getCssBlock(globalsCss, ".shell__rail::before");
 
-  assert.ok(shellRailRule, "expected .shell__rail rule to exist");
-  assert.ok(defaultRailRule, "expected .shell__rail--default rule to exist");
-  assert.ok(globalSidebarRule, "expected .global-sidebar rule to exist");
-  assert.ok(workspaceSidebarRule, "expected .workspace-sidebar rule to exist");
-
+  assert.ok(shellRailRule, "expected .shell__rail::before rule to exist");
   assert.equal(hasCssDeclaration(shellRailRule, "display"), false);
   assert.equal(hasCssDeclaration(shellRailRule, "gap"), false);
   assert.equal(hasCssDeclaration(shellRailRule, "align-content"), false);
-  assert.ok(hasCssDeclaration(defaultRailRule, "display"));
-  assert.ok(hasCssDeclaration(defaultRailRule, "gap"));
-  assert.ok(hasCssDeclaration(defaultRailRule, "align-content"));
-  assert.ok(hasCssDeclaration(globalSidebarRule, "display"));
-  assert.ok(hasCssDeclaration(globalSidebarRule, "align-content"));
-  assert.ok(hasCssDeclaration(workspaceSidebarRule, "display"));
-  assert.ok(hasCssDeclaration(workspaceSidebarRule, "align-content"));
+
+  for (const removedRootSelector of [
+    ".shell__rail--default",
+    ".global-sidebar",
+    ".workspace-sidebar",
+  ]) {
+    assert.equal(
+      new RegExp(`(^|\\n)${removedRootSelector.replace(".", "\\.")}\\s*\\{`, "m").test(globalsCss),
+      false,
+      `${removedRootSelector} root layout rule should not remain in globals.css`,
+    );
+  }
+
+  for (const retainedStateSelector of [
+    '.global-sidebar[data-collapsed="true"]',
+    '.workspace-sidebar[data-collapsed="true"]',
+    '.shell[data-sidebar-state="collapsed"]',
+  ]) {
+    assert.ok(
+      globalsCss.includes(retainedStateSelector),
+      `${retainedStateSelector} state selector should stay in globals.css`,
+    );
+  }
 });


### PR DESCRIPTION
## Linked Issue

Closes #1560

## Summary

- move migrated shell base layout and presentation from `globals.css` into component-owned Tailwind-backed classes
- keep collapsed-state and interaction selectors in `globals.css` where they still serve shared shell state
- relax shell markup tests so they verify semantic classes without depending on exact class ordering

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm --filter @collabsphere/web run test:unit`
- [x] `pnpm test:unit`
- [x] `pnpm --filter @collabsphere/web run build`

## Risks / Notes

- shell state selectors intentionally remain in `apps/web/src/app/globals.css`; this PR only extracts migrated base presentation
- Local CodeRabbit CLI review outcome: no findings on the committed diff

## Handoff

- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

## Handoff Summary

- shell surfaces now own their base layout/presentation while shared collapsed-state selectors stay centralized

## Handoff Validation Evidence

- lint, typecheck, web unit tests, root unit tests, and web build all passed locally

## Handoff Open Issues / Follow-ups

- none

## Handoff Risks / Deviations

- none

## Review Guidance

- Relevant spec / agent-ref docs: `apps/web/AGENTS.md`, `apps/web/REVIEW.md`, `docs/agent-ref/ops/frontend-baton-prompt-template.md`
- Areas that need extra scrutiny: shell layout parity, retained collapsed-state CSS selectors, semantic test coverage after utility-class adoption

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rick1330/collabsphere/pull/1564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
