### PR TITLE
feat(ui): expand owned primitive coverage

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -17,6 +17,7 @@ Local hard rules for `apps/web` implementation work. These are the Tier A fronte
 ### Styling And Component Rules
 - Style from tokens first; do not introduce raw ad hoc colors in feature components when tokenized or semantic styling already exists.
 - Prefer source-owned UI primitives for standard interaction patterns; do not hand-build menu, dialog, sheet, popover, or command behaviors if the accepted primitive layer covers them.
+- The current owned primitive inventory is documented in `docs/agent-ref/ui/owned-primitives.md`; extend that inventory only when a near-term delivery surface justifies it.
 - Every page or major section must handle Loading, Empty, Error, and Loaded states when the surface is data-driven.
 - Keep responsive behavior and accessibility as first-class contracts, not afterthoughts.
 
@@ -58,6 +59,7 @@ Local hard rules for `apps/web` implementation work. These are the Tier A fronte
 - `docs/agent-ref/ui/routes.md`
 - `docs/agent-ref/ui/page-states.md`
 - `docs/agent-ref/ui/component-patterns.md`
+- `docs/agent-ref/ui/owned-primitives.md`
 - `docs/agent-ref/ui/accessibility.md`
 - `docs/agent-ref/ui/responsive-rules.md`
 - `docs/agent-ref/ops/frontend-baton-prompt-template.md`

--- a/apps/web/REVIEW.md
+++ b/apps/web/REVIEW.md
@@ -14,6 +14,7 @@ Tier B frontend review defaults for `apps/web`. These guide review depth and qua
 - Prefer feature-scoped files and extracted helpers when a single component becomes difficult to review.
 - Avoid growing one-off foundation components into catch-all surfaces.
 - Reuse shared state components and primitive layers before adding new ad hoc patterns.
+- Check `docs/agent-ref/ui/owned-primitives.md` before accepting new one-off interaction mechanics in feature code.
 
 ### Design And Visual Quality
 - Review for hierarchy, spacing rhythm, and state clarity, not just correctness.
@@ -60,6 +61,7 @@ Tier B frontend review defaults for `apps/web`. These guide review depth and qua
 - `apps/web/AGENTS.md`
 - `docs/agent-ref/ui/accessibility.md`
 - `docs/agent-ref/ui/component-patterns.md`
+- `docs/agent-ref/ui/owned-primitives.md`
 - `docs/agent-ref/ui/page-states.md`
 - `docs/agent-ref/ui/responsive-rules.md`
 - `docs/agent-ref/ops/pr-review-workflow.md`

--- a/apps/web/src/test/ui-primitives.test.tsx
+++ b/apps/web/src/test/ui-primitives.test.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import {
+  Button,
+  Input,
+  Label,
+  Separator,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetTitle,
+  SheetTrigger,
+} from "@collabsphere/ui";
+
+describe("owned ui primitive coverage", () => {
+  it("renders basic form primitives with accessible label wiring", () => {
+    render(
+      <div>
+        <Label htmlFor="email">Email</Label>
+        <Input id="email" name="email" type="email" />
+        <Separator decorative={false} data-testid="separator" />
+        <Button type="submit">Continue</Button>
+      </div>,
+    );
+
+    expect(screen.getByLabelText("Email")).toHaveAttribute("type", "email");
+    expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled();
+    expect(screen.getByTestId("separator")).toHaveAttribute("role", "separator");
+  });
+
+  it("supports sheet open and close behavior through the owned primitive layer", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Sheet>
+        <SheetTrigger asChild>
+          <Button>Open navigation</Button>
+        </SheetTrigger>
+        <SheetContent side="left" aria-describedby="sheet-description">
+          <SheetTitle>Workspace navigation</SheetTitle>
+          <SheetDescription id="sheet-description">
+            Side-panel navigation contract for near-term delivery surfaces.
+          </SheetDescription>
+        </SheetContent>
+      </Sheet>,
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Open navigation" }));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Workspace navigation")).toBeVisible();
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -16,12 +16,12 @@ export default defineConfig({
         replacement: path.resolve(rootDir, "../../packages/ui/src/index.ts"),
       },
       {
-        find: "@collabsphere/ui/components/dialog",
-        replacement: path.resolve(rootDir, "../../packages/ui/src/components/dialog.tsx"),
+        find: /^@collabsphere\/ui\/components\/(.*)$/,
+        replacement: path.resolve(rootDir, "../../packages/ui/src/components/$1.tsx"),
       },
       {
-        find: "@collabsphere/ui/components/dropdown-menu",
-        replacement: path.resolve(rootDir, "../../packages/ui/src/components/dropdown-menu.tsx"),
+        find: /^@collabsphere\/ui\/lib\/(.*)$/,
+        replacement: path.resolve(rootDir, "../../packages/ui/src/lib/$1.ts"),
       },
       {
         find: /^@collabsphere\/shared$/,

--- a/docs/agent-ref/ui/owned-primitives.md
+++ b/docs/agent-ref/ui/owned-primitives.md
@@ -1,0 +1,40 @@
+# Owned UI Primitives
+
+## Purpose
+Define the current source-owned primitive layer in `packages/ui` so frontend delivery can reuse standard interaction building blocks instead of re-implementing them in feature code.
+
+## Current Primitive Set
+
+- `button`
+- `dialog`
+- `dropdown-menu`
+- `input`
+- `label`
+- `separator`
+- `sheet`
+
+## Selection Rules
+
+- Add primitives only when they unblock near-term delivery surfaces.
+- Prefer source-owned primitives for standard interaction mechanics before hand-building behavior in `apps/web`.
+- Do not bulk-install speculative primitives with no immediate consumer path.
+
+## Usage Guidance
+
+- Use `button`, `input`, and `label` for form and CTA surfaces before introducing ad hoc control classes.
+- Use `dialog` for centered modal flows.
+- Use `sheet` for mobile and side-panel surfaces that need dialog semantics with edge anchoring.
+- Use `dropdown-menu` for menu behavior; do not re-implement focus navigation for standard menu patterns.
+- Use `separator` for low-level visual grouping instead of repeated one-off border elements.
+
+## Out Of Scope
+
+- This file does not declare feature components, page layouts, or styling themes.
+- This file does not require every shadcn primitive to exist immediately.
+
+## References
+
+- `packages/ui/AGENTS.md`
+- `apps/web/AGENTS.md`
+- `apps/web/REVIEW.md`
+- `docs/agent-ref/ui/component-patterns.md`

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -8,6 +8,7 @@ Local rules for shared UI components and design patterns.
 
 ## Must Follow
 - Reuse shared components; avoid one-off UI patterns.
+- Keep the current primitive inventory documented in `docs/agent-ref/ui/owned-primitives.md` and update it when the owned layer expands.
 - Accessibility baseline is WCAG 2.1 AA.
 - Responsive behavior must follow canonical breakpoints and rules.
 - Use standard page-state patterns (Loading/Empty/Error/Loaded).
@@ -24,6 +25,7 @@ Local rules for shared UI components and design patterns.
 
 ## References
 - `docs/agent-ref/ui/component-patterns.md`
+- `docs/agent-ref/ui/owned-primitives.md`
 - `docs/agent-ref/ui/accessibility.md`
 - `docs/agent-ref/ui/responsive-rules.md`
 - `docs/agent-ref/ui/page-states.md`

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-label": "^2.1.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "../lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-[var(--radius-md)] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring-color)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-primary)] disabled:pointer-events-none disabled:opacity-60",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-[var(--color-accent)] text-[var(--color-bg-primary)] shadow-[var(--shadow-soft)] hover:bg-[var(--color-accent-hover)]",
+        secondary:
+          "border border-[var(--border-subtle)] bg-[var(--surface-card)] text-[var(--color-text-primary)] hover:bg-[var(--surface-card-subtle)]",
+        ghost:
+          "bg-transparent text-[var(--color-text-primary)] hover:bg-[color:color-mix(in_srgb,var(--surface-card)_82%,transparent)]",
+      },
+      size: {
+        default: "min-h-11 px-4 py-2",
+        sm: "min-h-9 rounded-[0.7rem] px-3 py-1.5 text-sm",
+        lg: "min-h-12 px-5 py-3 text-base",
+        icon: "h-11 w-11",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof buttonVariants>;
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, size, type = "button", variant, ...props }, ref) => (
+    <button
+      ref={ref}
+      type={type}
+      className={cn(buttonVariants({ variant, size }), className)}
+      {...props}
+    />
+  ),
+);
+
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "../lib/utils";
+
+type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => (
+  <input
+    ref={ref}
+    type={type}
+    className={cn(
+      "flex min-h-11 w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--surface-card)] px-3 py-2 text-sm text-[var(--color-text-primary)] shadow-[var(--shadow-soft)] transition-colors placeholder:text-[var(--color-text-tertiary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring-color)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-primary)] disabled:cursor-not-allowed disabled:opacity-60",
+      className,
+    )}
+    {...props}
+  />
+));
+
+Input.displayName = "Input";
+
+export { Input };

--- a/packages/ui/src/components/label.tsx
+++ b/packages/ui/src/components/label.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+
+import { cn } from "../lib/utils";
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(
+      "text-sm font-semibold leading-none text-[var(--color-text-primary)] peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      className,
+    )}
+    {...props}
+  />
+));
+
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };

--- a/packages/ui/src/components/separator.tsx
+++ b/packages/ui/src/components/separator.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "../lib/utils";
+
+type SeparatorProps = React.HTMLAttributes<HTMLDivElement> & {
+  decorative?: boolean;
+  orientation?: "horizontal" | "vertical";
+};
+
+const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>(
+  ({ className, decorative = true, orientation = "horizontal", ...props }, ref) => (
+    <div
+      ref={ref}
+      role={decorative ? "presentation" : "separator"}
+      aria-orientation={decorative ? undefined : orientation}
+      className={cn(
+        "shrink-0 bg-[var(--border-subtle)]",
+        orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+
+Separator.displayName = "Separator";
+
+export { Separator };

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+} from "./dialog";
+import { cn } from "../lib/utils";
+
+const sheetContentVariants = cva(
+  "fixed z-50 flex flex-col border border-[var(--border-subtle)] bg-[var(--surface-card)] text-[var(--color-text-primary)] shadow-[var(--shadow-elevated)] outline-none",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 rounded-b-[1.25rem] border-x-0 border-t-0",
+        bottom: "inset-x-0 bottom-0 rounded-t-[1.25rem] border-x-0 border-b-0",
+        left: "inset-y-0 left-0 h-full w-full max-w-md rounded-r-[1.25rem] border-y-0 border-l-0",
+        right: "inset-y-0 right-0 h-full w-full max-w-md rounded-l-[1.25rem] border-y-0 border-r-0",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  },
+);
+
+type SheetContentProps = React.ComponentPropsWithoutRef<typeof DialogContent> &
+  VariantProps<typeof sheetContentVariants>;
+
+const Sheet = Dialog;
+const SheetTrigger = DialogTrigger;
+const SheetClose = DialogClose;
+const SheetPortal = DialogPortal;
+const SheetTitle = DialogTitle;
+const SheetDescription = DialogDescription;
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogOverlay>,
+  React.ComponentPropsWithoutRef<typeof DialogOverlay>
+>(({ className, ...props }, ref) => (
+  <DialogOverlay ref={ref} className={cn("bg-foreground/45", className)} {...props} />
+));
+
+SheetOverlay.displayName = "SheetOverlay";
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof DialogContent>,
+  SheetContentProps
+>(({ className, side, ...props }, ref) => (
+  <DialogPortal>
+    <SheetOverlay />
+    <DialogContent
+      ref={ref}
+      className={cn(sheetContentVariants({ side }), className)}
+      {...props}
+    />
+  </DialogPortal>
+));
+
+SheetContent.displayName = "SheetContent";
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetOverlay,
+  SheetPortal,
+  SheetTitle,
+  SheetTrigger,
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,3 +1,8 @@
 export { cn } from "./lib/utils";
+export * from "./components/button";
 export * from "./components/dialog";
 export * from "./components/dropdown-menu";
+export * from "./components/input";
+export * from "./components/label";
+export * from "./components/separator";
+export * from "./components/sheet";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.16
         version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-label':
+        specifier: ^2.1.7
+        version: 2.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -820,6 +823,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-label@2.1.8':
+    resolution: {integrity: sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-menu@2.1.16':
     resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
     peerDependencies:
@@ -885,6 +901,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.1.4':
+    resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
@@ -900,6 +929,15 @@ packages:
 
   '@radix-ui/react-slot@1.2.3':
     resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.4':
+    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2932,6 +2970,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-label@2.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -3005,6 +3052,15 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -3023,6 +3079,13 @@ snapshots:
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4


### PR DESCRIPTION
## Linked Issue

Closes #1561

## Summary

- add the next minimal source-owned primitive set in `packages/ui`: `button`, `input`, `label`, `separator`, and `sheet`
- widen the web Vitest alias contract so new `@collabsphere/ui/components/*` surfaces resolve truthfully in tests
- document the current owned primitive inventory and add a web-level primitive usability test

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm --filter @collabsphere/web run test:unit`
- [x] `pnpm test:unit`
- [x] `pnpm --filter @collabsphere/web run build`

## Risks / Notes

- primitive expansion stays intentionally narrow; this PR does not bulk-install speculative widgets
- Local CodeRabbit CLI review outcome: final committed-diff attempt hit service rate limiting after setup; no code finding was returned

## Handoff

- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

## Handoff Summary

- the owned primitive layer now covers the immediate next-wave shell and auth-form delivery needs without widening into unused component inventory

## Handoff Validation Evidence

- lint, typecheck, web unit tests, root unit tests, and web build passed locally

## Handoff Open Issues / Follow-ups

- none

## Handoff Risks / Deviations

- none

## Review Guidance

- Relevant spec / agent-ref docs: `docs/agent-ref/ui/owned-primitives.md`, `apps/web/AGENTS.md`, `apps/web/REVIEW.md`
- Areas that need extra scrutiny: primitive API shape, sheet behavior contract, and keeping the primitive set tactical rather than speculative

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rick1330/collabsphere/pull/1565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
