### PR TITLE
fix(ui): resolve post-merge primitive review findings

### DIFF
--- a/apps/web/src/test/ui-primitives.test.tsx
+++ b/apps/web/src/test/ui-primitives.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 
@@ -57,6 +57,8 @@ describe("owned ui primitive coverage", () => {
 
     await user.keyboard("{Escape}");
 
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/ui/src/components/separator.tsx
+++ b/packages/ui/src/components/separator.tsx
@@ -13,6 +13,7 @@ const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>(
   ({ className, decorative = true, orientation = "horizontal", ...props }, ref) => (
     <div
       ref={ref}
+      {...props}
       role={decorative ? "presentation" : "separator"}
       aria-orientation={decorative ? undefined : orientation}
       className={cn(
@@ -20,7 +21,6 @@ const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>(
         orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
         className,
       )}
-      {...props}
     />
   ),
 );

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -20,10 +20,10 @@ const sheetContentVariants = cva(
   {
     variants: {
       side: {
-        top: "inset-x-0 top-0 rounded-b-[1.25rem] border-x-0 border-t-0",
-        bottom: "inset-x-0 bottom-0 rounded-t-[1.25rem] border-x-0 border-b-0",
-        left: "inset-y-0 left-0 h-full w-full max-w-md rounded-r-[1.25rem] border-y-0 border-l-0",
-        right: "inset-y-0 right-0 h-full w-full max-w-md rounded-l-[1.25rem] border-y-0 border-r-0",
+        top: "inset-x-0 top-0 rounded-none rounded-b-[1.25rem] border-x-0 border-t-0",
+        bottom: "inset-x-0 bottom-0 rounded-none rounded-t-[1.25rem] border-x-0 border-b-0",
+        left: "inset-y-0 left-0 h-full w-full max-w-md rounded-none rounded-r-[1.25rem] border-y-0 border-l-0",
+        right: "inset-y-0 right-0 h-full w-full max-w-md rounded-none rounded-l-[1.25rem] border-y-0 border-r-0",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Linked Issue

Follow-up to #1565. Refs #1555.

## Summary

- enforce separator semantics by preventing caller overrides of computed accessibility attributes
- remove leaked dialog corner rounding from sheet side variants
- harden the new primitive-layer sheet test against Radix close timing

## Validation

- [x] pnpm lint
- [x] pnpm typecheck
- [x] pnpm --filter @collabsphere/web run test:unit -- ui-primitives.test.tsx
- [x] pnpm test:unit
- [x] pnpm --filter @collabsphere/web run build
- [x] pnpm review:coderabbit -- review --type committed --base main

## Risks / Notes

- narrow follow-up PR for three post-merge Copilot findings on the newly introduced primitive layer
- does not widen into the next migration baton

## Handoff

- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

## Handoff Summary

- opened a narrow remediation PR to resolve valid Copilot findings that arrived after #1565 merged

## Handoff Validation Evidence

- local validation and CodeRabbit review completed cleanly on commit 49a8dc0b19f433304a144b05b7a1c18e9b6cfb22

## Handoff Open Issues / Follow-ups

- wait for Devin and Copilot review on this PR before merge

## Handoff Risks / Deviations

- none

## Review Guidance

- Relevant spec / agent-ref docs: pps/web/AGENTS.md, pps/web/REVIEW.md, docs/agent-ref/ui/owned-primitives.md
- Areas that need extra scrutiny: separator semantics, sheet side rounding, Radix close timing in the primitive-layer test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rick1330/collabsphere/pull/1566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
