### PR TITLE
feat(api): implement CS-021 soft delete access rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -299,6 +299,17 @@ Follow these rules for schema work:
 - Preserve spec-required partial indexes, GIN indexes, and unique constraints even when they must be expressed in migration SQL instead of Prisma schema syntax
 - Prefer additive migrations; do not use destructive shortcut changes without a backfill and review plan
 
+### Soft Delete Conventions
+
+For user-facing persistence surfaces, treat soft delete as the default lifecycle rule:
+
+- Covered entities are `users`, `workspaces`, `workspace_members`, `invitations`, `folders`, `documents`, `task_columns`, `tasks`, `task_document_links`, `comment_threads`, `comments`, `notifications`, `export_jobs`, `files`, and `attachments`.
+- Standard application reads must exclude deleted rows by default. In the API layer, use the Prisma wrapper in `apps/api/src/common/prisma/soft-delete.middleware.ts` and `apps/api/src/common/prisma/prisma.service.ts` instead of repeating `deletedAt: null` in each query.
+- Recovery or admin flows that need deleted rows must opt in explicitly through `prisma.$withDeleted()`.
+- Hard deletes are reserved for purge workflows. Use `prisma.$withHardDeletes()` only in those workflows; ordinary application code must not call hard delete directly.
+- When a uniqueness rule only applies to active rows, preserve the matching partial unique index with `WHERE deleted_at IS NULL` in migration SQL.
+- If a recovery flow is not implemented yet, record the gap in the issue or PR rather than bypassing soft delete behavior ad hoc.
+
 Recommended schema workflow:
 
 ```bash

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/dev.ts",
-    "build": "pnpm exec tsc -p tsconfig.json && tsx ../../scripts/build-bootstrap-app.ts ."
+    "build": "pnpm exec tsc -p tsconfig.json && tsx ../../scripts/build-bootstrap-app.ts .",
+    "test": "pnpm exec tsx --test --test-concurrency=1 ../../tests/unit/api-bootstrap-env.test.ts ../../tests/unit/api-email-config.test.ts ../../tests/unit/api-soft-delete-prisma.test.ts"
   }
 }

--- a/apps/api/src/common/prisma/prisma.service.ts
+++ b/apps/api/src/common/prisma/prisma.service.ts
@@ -1,0 +1,15 @@
+import {
+  createSoftDeletePrismaClient,
+  type SoftDeleteClientControls,
+} from "./soft-delete.middleware.js";
+
+export type PrismaService<TClient extends object> = TClient & SoftDeleteClientControls<TClient>;
+
+export const createPrismaService = <TClient extends object>(client: TClient): PrismaService<TClient> =>
+  createSoftDeletePrismaClient(client);
+
+export const withDeletedRecords = <TClient extends object>(client: PrismaService<TClient>) =>
+  client.$withDeleted();
+
+export const withHardDeletes = <TClient extends object>(client: PrismaService<TClient>) =>
+  client.$withHardDeletes();

--- a/apps/api/src/common/prisma/soft-delete.middleware.ts
+++ b/apps/api/src/common/prisma/soft-delete.middleware.ts
@@ -115,22 +115,51 @@ export const normalizeSoftDeleteReadArgs = ({
   return nextArgs;
 };
 
+const createSoftDeleteMutationData = ({
+  args,
+  now = () => new Date(),
+}: {
+  args: Record<string, unknown>;
+  now?: () => Date;
+}) => ({
+  ...cloneData(args.data),
+  deletedAt: now(),
+});
+
+const normalizeSoftDeleteWriteArgs = ({
+  args,
+  now = () => new Date(),
+  where,
+}: {
+  args: unknown;
+  now?: () => Date;
+  where?: unknown;
+}) => {
+  const nextArgs = cloneArgs(args);
+
+  if (where !== undefined) {
+    nextArgs.where = where;
+  }
+
+  nextArgs.data = createSoftDeleteMutationData({
+    args: nextArgs,
+    now,
+  });
+
+  return nextArgs;
+};
+
 export const normalizeSoftDeleteDeleteArgs = ({
   args,
   now = () => new Date(),
 }: {
   args: unknown;
   now?: () => Date;
-}) => {
-  const nextArgs = cloneArgs(args);
-
-  nextArgs.data = {
-    ...cloneData(nextArgs.data),
-    deletedAt: now(),
-  };
-
-  return nextArgs;
-};
+}) =>
+  normalizeSoftDeleteWriteArgs({
+    args,
+    now,
+  });
 
 export const normalizeSoftDeleteDeleteManyArgs = ({
   args,
@@ -138,18 +167,14 @@ export const normalizeSoftDeleteDeleteManyArgs = ({
 }: {
   args: unknown;
   now?: () => Date;
-}) => {
-  const nextArgs = cloneArgs(args);
-
-  nextArgs.where = addDefaultSoftDeleteWhere({
-    where: nextArgs.where,
+}) =>
+  normalizeSoftDeleteWriteArgs({
+    args,
+    now,
+    where: addDefaultSoftDeleteWhere({
+      where: cloneArgs(args).where,
+    }),
   });
-  nextArgs.data = {
-    deletedAt: now(),
-  };
-
-  return nextArgs;
-};
 
 const createReadOperationHandler = ({
   method,
@@ -250,23 +275,19 @@ const createPassthroughHandler = ({
   (...args: unknown[]) =>
     Reflect.apply(method, target, args);
 
-const resolveDelegateProperty = ({
+const resolveReadOperationHandler = ({
   property,
-  value,
   target,
   receiver,
+  value,
   options,
 }: {
   property: string;
-  value: unknown;
   target: object;
   receiver: object;
+  value: UnknownFn;
   options: SoftDeleteProxyOptions;
 }) => {
-  if (!isCallable(value)) {
-    return value;
-  }
-
   if (property === "findUnique" || property === "findUniqueOrThrow") {
     return createUniqueReadOperationHandler({
       target,
@@ -284,6 +305,20 @@ const resolveDelegateProperty = ({
     });
   }
 
+  return null;
+};
+
+const resolveWriteOperationHandler = ({
+  property,
+  target,
+  receiver,
+  options,
+}: {
+  property: string;
+  target: object;
+  receiver: object;
+  options: SoftDeleteProxyOptions;
+}) => {
   if (property === "delete" && !options.allowHardDelete) {
     return createMutationOperationHandler({
       target,
@@ -310,6 +345,47 @@ const resolveDelegateProperty = ({
           now: options.now,
         }),
     });
+  }
+
+  return null;
+};
+
+const resolveDelegateProperty = ({
+  property,
+  value,
+  target,
+  receiver,
+  options,
+}: {
+  property: string;
+  value: unknown;
+  target: object;
+  receiver: object;
+  options: SoftDeleteProxyOptions;
+}) => {
+  if (!isCallable(value)) {
+    return value;
+  }
+
+  const readOperationHandler = resolveReadOperationHandler({
+    property,
+    target,
+    receiver,
+    value,
+    options,
+  });
+  if (readOperationHandler) {
+    return readOperationHandler;
+  }
+
+  const writeOperationHandler = resolveWriteOperationHandler({
+    property,
+    target,
+    receiver,
+    options,
+  });
+  if (writeOperationHandler) {
+    return writeOperationHandler;
   }
 
   return createPassthroughHandler({

--- a/apps/api/src/common/prisma/soft-delete.middleware.ts
+++ b/apps/api/src/common/prisma/soft-delete.middleware.ts
@@ -1,0 +1,241 @@
+export const SOFT_DELETE_MODELS = [
+  "User",
+  "Workspace",
+  "WorkspaceMember",
+  "Invitation",
+  "Folder",
+  "Document",
+  "TaskColumn",
+  "Task",
+  "TaskDocumentLink",
+  "CommentThread",
+  "Comment",
+  "Notification",
+  "ExportJob",
+  "File",
+  "Attachment",
+] as const;
+
+export const SOFT_DELETE_READ_OPERATIONS = [
+  "findUnique",
+  "findUniqueOrThrow",
+  "findFirst",
+  "findFirstOrThrow",
+  "findMany",
+  "count",
+  "aggregate",
+  "groupBy",
+] as const;
+
+export const SOFT_DELETE_DELEGATE_KEYS = SOFT_DELETE_MODELS.map((modelName) =>
+  modelName[0].toLowerCase() + modelName.slice(1),
+);
+
+type RecordLike = Record<string | symbol, unknown>;
+
+export type SoftDeleteProxyOptions = {
+  includeDeleted?: boolean;
+  allowHardDelete?: boolean;
+  now?: () => Date;
+};
+
+export type SoftDeleteClientControls<TClient extends object = object> = {
+  $withDeleted(): TClient & SoftDeleteClientControls<TClient>;
+  $withHardDeletes(): TClient & SoftDeleteClientControls<TClient>;
+};
+
+const SOFT_DELETE_MODEL_SET = new Set<string>(SOFT_DELETE_DELEGATE_KEYS);
+const SOFT_DELETE_READ_OPERATION_SET = new Set<string>(SOFT_DELETE_READ_OPERATIONS);
+
+const isRecordLike = (value: unknown): value is RecordLike =>
+  typeof value === "object" && value !== null;
+
+const cloneArgs = (args: unknown): Record<string, unknown> => {
+  if (!isRecordLike(args)) {
+    return {};
+  }
+
+  return { ...(args as Record<string, unknown>) };
+};
+
+const cloneData = (value: unknown) => {
+  if (!isRecordLike(value)) {
+    return {};
+  }
+
+  return { ...(value as Record<string, unknown>) };
+};
+
+export const addDefaultSoftDeleteWhere = ({
+  where,
+  includeDeleted = false,
+}: {
+  where: unknown;
+  includeDeleted?: boolean;
+}) => {
+  if (includeDeleted) {
+    return where;
+  }
+
+  if (!isRecordLike(where) || Object.keys(where).length === 0) {
+    return { deletedAt: null };
+  }
+
+  if ("deletedAt" in where) {
+    return where;
+  }
+
+  return {
+    AND: [where, { deletedAt: null }],
+  };
+};
+
+export const normalizeSoftDeleteReadArgs = ({
+  args,
+  includeDeleted = false,
+}: {
+  args: unknown;
+  includeDeleted?: boolean;
+}) => {
+  const nextArgs = cloneArgs(args);
+
+  nextArgs.where = addDefaultSoftDeleteWhere({
+    where: nextArgs.where,
+    includeDeleted,
+  });
+
+  return nextArgs;
+};
+
+export const normalizeSoftDeleteDeleteArgs = ({
+  args,
+  now = () => new Date(),
+}: {
+  args: unknown;
+  now?: () => Date;
+}) => {
+  const nextArgs = cloneArgs(args);
+
+  nextArgs.data = {
+    ...cloneData(nextArgs.data),
+    deletedAt: now(),
+  };
+
+  return nextArgs;
+};
+
+export const normalizeSoftDeleteDeleteManyArgs = ({
+  args,
+  includeDeleted = false,
+  now = () => new Date(),
+}: {
+  args: unknown;
+  includeDeleted?: boolean;
+  now?: () => Date;
+}) => {
+  const nextArgs = cloneArgs(args);
+
+  nextArgs.where = addDefaultSoftDeleteWhere({
+    where: nextArgs.where,
+    includeDeleted,
+  });
+  nextArgs.data = {
+    deletedAt: now(),
+  };
+
+  return nextArgs;
+};
+
+export const createSoftDeleteDelegateProxy = <TDelegate extends object>(
+  delegate: TDelegate,
+  options: SoftDeleteProxyOptions = {},
+) =>
+  new Proxy(delegate, {
+    get(target, property, receiver) {
+      if (typeof property !== "string") {
+        return Reflect.get(target, property, receiver);
+      }
+
+      const value = Reflect.get(target, property, receiver);
+      if (typeof value !== "function") {
+        return value;
+      }
+
+      if (SOFT_DELETE_READ_OPERATION_SET.has(property)) {
+        return (args?: unknown) =>
+          Reflect.apply(value, target, [
+            normalizeSoftDeleteReadArgs({
+              args,
+              includeDeleted: options.includeDeleted,
+            }),
+          ]);
+      }
+
+      if (property === "delete" && !options.allowHardDelete) {
+        return (args?: unknown) => {
+          const update = Reflect.get(target, "update", receiver);
+          if (typeof update !== "function") {
+            throw new Error("Soft delete proxy requires an update() delegate method.");
+          }
+
+          return Reflect.apply(update, target, [
+            normalizeSoftDeleteDeleteArgs({
+              args,
+              now: options.now,
+            }),
+          ]);
+        };
+      }
+
+      if (property === "deleteMany" && !options.allowHardDelete) {
+        return (args?: unknown) => {
+          const updateMany = Reflect.get(target, "updateMany", receiver);
+          if (typeof updateMany !== "function") {
+            throw new Error("Soft delete proxy requires an updateMany() delegate method.");
+          }
+
+          return Reflect.apply(updateMany, target, [
+            normalizeSoftDeleteDeleteManyArgs({
+              args,
+              includeDeleted: options.includeDeleted,
+              now: options.now,
+            }),
+          ]);
+        };
+      }
+
+      return (...args: unknown[]) => Reflect.apply(value, target, args);
+    },
+  });
+
+export const createSoftDeletePrismaClient = <TClient extends object>(
+  client: TClient,
+  options: SoftDeleteProxyOptions = {},
+) =>
+  new Proxy(client, {
+    get(target, property, receiver) {
+      if (property === "$withDeleted") {
+        return () =>
+          createSoftDeletePrismaClient(target, {
+            ...options,
+            includeDeleted: true,
+          });
+      }
+
+      if (property === "$withHardDeletes") {
+        return () =>
+          createSoftDeletePrismaClient(target, {
+            ...options,
+            allowHardDelete: true,
+            includeDeleted: true,
+          });
+      }
+
+      const value = Reflect.get(target, property, receiver);
+      if (typeof property === "string" && SOFT_DELETE_MODEL_SET.has(property) && isRecordLike(value)) {
+        return createSoftDeleteDelegateProxy(value, options);
+      }
+
+      return value;
+    },
+  }) as TClient & SoftDeleteClientControls<TClient>;

--- a/apps/api/src/common/prisma/soft-delete.middleware.ts
+++ b/apps/api/src/common/prisma/soft-delete.middleware.ts
@@ -47,6 +47,10 @@ export type SoftDeleteClientControls<TClient extends object = object> = {
 
 const SOFT_DELETE_MODEL_SET = new Set<string>(SOFT_DELETE_DELEGATE_KEYS);
 const SOFT_DELETE_READ_OPERATION_SET = new Set<string>(SOFT_DELETE_READ_OPERATIONS);
+const UNIQUE_READ_OPERATION_MAP = {
+  findUnique: "findFirst",
+  findUniqueOrThrow: "findFirstOrThrow",
+} as const;
 
 const isRecordLike = (value: unknown): value is RecordLike =>
   typeof value === "object" && value !== null;
@@ -130,18 +134,15 @@ export const normalizeSoftDeleteDeleteArgs = ({
 
 export const normalizeSoftDeleteDeleteManyArgs = ({
   args,
-  includeDeleted = false,
   now = () => new Date(),
 }: {
   args: unknown;
-  includeDeleted?: boolean;
   now?: () => Date;
 }) => {
   const nextArgs = cloneArgs(args);
 
   nextArgs.where = addDefaultSoftDeleteWhere({
     where: nextArgs.where,
-    includeDeleted,
   });
   nextArgs.data = {
     deletedAt: now(),
@@ -175,70 +176,68 @@ const resolveRequiredDelegateMethod = ({
 }: {
   target: object;
   receiver: object;
-  methodName: "update" | "updateMany";
+  methodName: string;
   errorMessage: string;
 }) => {
   const delegateMethod = Reflect.get(target, methodName, receiver);
-  if (typeof delegateMethod !== "function") {
+  if (!isCallable(delegateMethod)) {
     throw new Error(errorMessage);
   }
 
-  return delegateMethod as (...args: unknown[]) => unknown;
+  return delegateMethod;
 };
 
-const createDeleteOperationHandler = ({
+const createUniqueReadOperationHandler = ({
   target,
   receiver,
-  now,
+  methodName,
+  includeDeleted,
 }: {
   target: object;
   receiver: object;
-  now?: () => Date;
+  methodName: "findFirst" | "findFirstOrThrow";
+  includeDeleted?: boolean;
 }) =>
   (args?: unknown) =>
     Reflect.apply(
       resolveRequiredDelegateMethod({
         target,
         receiver,
-        methodName: "update",
-        errorMessage: "Soft delete proxy requires an update() delegate method.",
+        methodName,
+        errorMessage: `Soft delete proxy requires a ${methodName}() delegate method.`,
       }),
       target,
       [
-        normalizeSoftDeleteDeleteArgs({
+        normalizeSoftDeleteReadArgs({
           args,
-          now,
+          includeDeleted,
         }),
       ],
     );
 
-const createDeleteManyOperationHandler = ({
+const createMutationOperationHandler = ({
   target,
   receiver,
-  includeDeleted,
-  now,
+  methodName,
+  errorMessage,
+  normalizeArgs,
 }: {
   target: object;
   receiver: object;
-  includeDeleted?: boolean;
-  now?: () => Date;
+  methodName: "update" | "updateMany";
+  errorMessage: string;
+  normalizeArgs: (args: unknown) => Record<string, unknown>;
 }) =>
   (args?: unknown) =>
     Reflect.apply(
       resolveRequiredDelegateMethod({
         target,
         receiver,
-        methodName: "updateMany",
-        errorMessage: "Soft delete proxy requires an updateMany() delegate method.",
+        methodName,
+        errorMessage,
       }),
       target,
-      [
-        normalizeSoftDeleteDeleteManyArgs({
-          args,
-          includeDeleted,
-          now,
-        }),
-      ],
+      [normalizeArgs(args)],
     );
 
 const createPassthroughHandler = ({
@@ -268,6 +267,15 @@ const resolveDelegateProperty = ({
     return value;
   }
 
+  if (property === "findUnique" || property === "findUniqueOrThrow") {
+    return createUniqueReadOperationHandler({
+      target,
+      receiver,
+      methodName: UNIQUE_READ_OPERATION_MAP[property],
+      includeDeleted: options.includeDeleted,
+    });
+  }
+
   if (SOFT_DELETE_READ_OPERATION_SET.has(property)) {
     return createReadOperationHandler({
       method: value,
@@ -277,19 +285,30 @@ const resolveDelegateProperty = ({
   }
 
   if (property === "delete" && !options.allowHardDelete) {
-    return createDeleteOperationHandler({
+    return createMutationOperationHandler({
       target,
       receiver,
-      now: options.now,
+      methodName: "update",
+      errorMessage: "Soft delete proxy requires an update() delegate method.",
+      normalizeArgs: (args) =>
+        normalizeSoftDeleteDeleteArgs({
+          args,
+          now: options.now,
+        }),
     });
   }
 
   if (property === "deleteMany" && !options.allowHardDelete) {
-    return createDeleteManyOperationHandler({
+    return createMutationOperationHandler({
       target,
       receiver,
-      includeDeleted: options.includeDeleted,
-      now: options.now,
+      methodName: "updateMany",
+      errorMessage: "Soft delete proxy requires an updateMany() delegate method.",
+      normalizeArgs: (args) =>
+        normalizeSoftDeleteDeleteManyArgs({
+          args,
+          now: options.now,
+        }),
     });
   }
 

--- a/apps/api/src/common/prisma/soft-delete.middleware.ts
+++ b/apps/api/src/common/prisma/soft-delete.middleware.ts
@@ -32,6 +32,7 @@ export const SOFT_DELETE_DELEGATE_KEYS = SOFT_DELETE_MODELS.map((modelName) =>
 );
 
 type RecordLike = Record<string | symbol, unknown>;
+type UnknownFn = (...args: unknown[]) => unknown;
 
 export type SoftDeleteProxyOptions = {
   includeDeleted?: boolean;
@@ -49,6 +50,9 @@ const SOFT_DELETE_READ_OPERATION_SET = new Set<string>(SOFT_DELETE_READ_OPERATIO
 
 const isRecordLike = (value: unknown): value is RecordLike =>
   typeof value === "object" && value !== null;
+
+const isCallable = (value: unknown): value is UnknownFn =>
+  typeof value === "function";
 
 const cloneArgs = (args: unknown): Record<string, unknown> => {
   if (!isRecordLike(args)) {
@@ -146,6 +150,187 @@ export const normalizeSoftDeleteDeleteManyArgs = ({
   return nextArgs;
 };
 
+const createReadOperationHandler = ({
+  method,
+  target,
+  includeDeleted,
+}: {
+  method: (...args: unknown[]) => unknown;
+  target: object;
+  includeDeleted?: boolean;
+}) =>
+  (args?: unknown) =>
+    Reflect.apply(method, target, [
+      normalizeSoftDeleteReadArgs({
+        args,
+        includeDeleted,
+      }),
+    ]);
+
+const resolveRequiredDelegateMethod = ({
+  target,
+  receiver,
+  methodName,
+  errorMessage,
+}: {
+  target: object;
+  receiver: object;
+  methodName: "update" | "updateMany";
+  errorMessage: string;
+}) => {
+  const delegateMethod = Reflect.get(target, methodName, receiver);
+  if (typeof delegateMethod !== "function") {
+    throw new Error(errorMessage);
+  }
+
+  return delegateMethod as (...args: unknown[]) => unknown;
+};
+
+const createDeleteOperationHandler = ({
+  target,
+  receiver,
+  now,
+}: {
+  target: object;
+  receiver: object;
+  now?: () => Date;
+}) =>
+  (args?: unknown) =>
+    Reflect.apply(
+      resolveRequiredDelegateMethod({
+        target,
+        receiver,
+        methodName: "update",
+        errorMessage: "Soft delete proxy requires an update() delegate method.",
+      }),
+      target,
+      [
+        normalizeSoftDeleteDeleteArgs({
+          args,
+          now,
+        }),
+      ],
+    );
+
+const createDeleteManyOperationHandler = ({
+  target,
+  receiver,
+  includeDeleted,
+  now,
+}: {
+  target: object;
+  receiver: object;
+  includeDeleted?: boolean;
+  now?: () => Date;
+}) =>
+  (args?: unknown) =>
+    Reflect.apply(
+      resolveRequiredDelegateMethod({
+        target,
+        receiver,
+        methodName: "updateMany",
+        errorMessage: "Soft delete proxy requires an updateMany() delegate method.",
+      }),
+      target,
+      [
+        normalizeSoftDeleteDeleteManyArgs({
+          args,
+          includeDeleted,
+          now,
+        }),
+      ],
+    );
+
+const createPassthroughHandler = ({
+  method,
+  target,
+}: {
+  method: (...args: unknown[]) => unknown;
+  target: object;
+}) =>
+  (...args: unknown[]) =>
+    Reflect.apply(method, target, args);
+
+const resolveDelegateProperty = ({
+  property,
+  value,
+  target,
+  receiver,
+  options,
+}: {
+  property: string;
+  value: unknown;
+  target: object;
+  receiver: object;
+  options: SoftDeleteProxyOptions;
+}) => {
+  if (!isCallable(value)) {
+    return value;
+  }
+
+  if (SOFT_DELETE_READ_OPERATION_SET.has(property)) {
+    return createReadOperationHandler({
+      method: value,
+      target,
+      includeDeleted: options.includeDeleted,
+    });
+  }
+
+  if (property === "delete" && !options.allowHardDelete) {
+    return createDeleteOperationHandler({
+      target,
+      receiver,
+      now: options.now,
+    });
+  }
+
+  if (property === "deleteMany" && !options.allowHardDelete) {
+    return createDeleteManyOperationHandler({
+      target,
+      receiver,
+      includeDeleted: options.includeDeleted,
+      now: options.now,
+    });
+  }
+
+  return createPassthroughHandler({
+    method: value,
+    target,
+  });
+};
+
+const resolveClientControl = ({
+  target,
+  property,
+  options,
+}: {
+  target: object;
+  property: string | symbol;
+  options: SoftDeleteProxyOptions;
+}) => {
+  if (property === "$withDeleted") {
+    return () =>
+      createSoftDeletePrismaClient(target, {
+        ...options,
+        includeDeleted: true,
+      });
+  }
+
+  if (property === "$withHardDeletes") {
+    return () =>
+      createSoftDeletePrismaClient(target, {
+        ...options,
+        allowHardDelete: true,
+        includeDeleted: true,
+      });
+  }
+
+  return null;
+};
+
+const shouldWrapSoftDeleteDelegate = (property: string | symbol, value: unknown) =>
+  typeof property === "string" && SOFT_DELETE_MODEL_SET.has(property) && isRecordLike(value);
+
 export const createSoftDeleteDelegateProxy = <TDelegate extends object>(
   delegate: TDelegate,
   options: SoftDeleteProxyOptions = {},
@@ -156,55 +341,13 @@ export const createSoftDeleteDelegateProxy = <TDelegate extends object>(
         return Reflect.get(target, property, receiver);
       }
 
-      const value = Reflect.get(target, property, receiver);
-      if (typeof value !== "function") {
-        return value;
-      }
-
-      if (SOFT_DELETE_READ_OPERATION_SET.has(property)) {
-        return (args?: unknown) =>
-          Reflect.apply(value, target, [
-            normalizeSoftDeleteReadArgs({
-              args,
-              includeDeleted: options.includeDeleted,
-            }),
-          ]);
-      }
-
-      if (property === "delete" && !options.allowHardDelete) {
-        return (args?: unknown) => {
-          const update = Reflect.get(target, "update", receiver);
-          if (typeof update !== "function") {
-            throw new Error("Soft delete proxy requires an update() delegate method.");
-          }
-
-          return Reflect.apply(update, target, [
-            normalizeSoftDeleteDeleteArgs({
-              args,
-              now: options.now,
-            }),
-          ]);
-        };
-      }
-
-      if (property === "deleteMany" && !options.allowHardDelete) {
-        return (args?: unknown) => {
-          const updateMany = Reflect.get(target, "updateMany", receiver);
-          if (typeof updateMany !== "function") {
-            throw new Error("Soft delete proxy requires an updateMany() delegate method.");
-          }
-
-          return Reflect.apply(updateMany, target, [
-            normalizeSoftDeleteDeleteManyArgs({
-              args,
-              includeDeleted: options.includeDeleted,
-              now: options.now,
-            }),
-          ]);
-        };
-      }
-
-      return (...args: unknown[]) => Reflect.apply(value, target, args);
+      return resolveDelegateProperty({
+        property,
+        value: Reflect.get(target, property, receiver),
+        target,
+        receiver,
+        options,
+      });
     },
   });
 
@@ -214,26 +357,18 @@ export const createSoftDeletePrismaClient = <TClient extends object>(
 ) =>
   new Proxy(client, {
     get(target, property, receiver) {
-      if (property === "$withDeleted") {
-        return () =>
-          createSoftDeletePrismaClient(target, {
-            ...options,
-            includeDeleted: true,
-          });
-      }
-
-      if (property === "$withHardDeletes") {
-        return () =>
-          createSoftDeletePrismaClient(target, {
-            ...options,
-            allowHardDelete: true,
-            includeDeleted: true,
-          });
+      const clientControl = resolveClientControl({
+        target,
+        property,
+        options,
+      });
+      if (clientControl) {
+        return clientControl;
       }
 
       const value = Reflect.get(target, property, receiver);
-      if (typeof property === "string" && SOFT_DELETE_MODEL_SET.has(property) && isRecordLike(value)) {
-        return createSoftDeleteDelegateProxy(value, options);
+      if (shouldWrapSoftDeleteDelegate(property, value)) {
+        return createSoftDeleteDelegateProxy(value as object, options);
       }
 
       return value;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "pnpm exec eslint . --max-warnings=0",
     "typecheck": "pnpm exec tsc -p packages/shared/tsconfig.json --noEmit && pnpm exec tsc -p packages/ui/tsconfig.json --noEmit && pnpm exec tsc -p packages/database/tsconfig.json --noEmit && pnpm --filter @collabsphere/web run typecheck",
     "test": "pnpm exec turbo run //#test:unit && pnpm exec turbo run //#test:integration --env-mode=loose",
-    "test:unit": "pnpm --filter @collabsphere/web run test:unit && pnpm exec tsx --test .github/scripts/story-project-gates.test.ts tests/unit/api-bootstrap-env.test.ts tests/unit/api-email-config.test.ts tests/unit/ci-workflow.test.ts tests/unit/collab-worker-bootstrap-env.test.ts tests/unit/integration-fixtures.test.ts tests/unit/shared-env.test.ts tests/unit/shared-prisma-enums.test.ts",
+    "test:unit": "pnpm --filter @collabsphere/web run test:unit && pnpm exec tsx --test --test-concurrency=1 .github/scripts/story-project-gates.test.ts tests/unit/api-bootstrap-env.test.ts tests/unit/api-email-config.test.ts tests/unit/api-soft-delete-prisma.test.ts tests/unit/ci-workflow.test.ts tests/unit/collab-worker-bootstrap-env.test.ts tests/unit/integration-fixtures.test.ts tests/unit/shared-env.test.ts tests/unit/shared-prisma-enums.test.ts",
     "test:integration": "node --test tests/integration",
     "build": "pnpm exec turbo run build",
     "build:web": "pnpm --filter @collabsphere/web run build",

--- a/scripts/build-bootstrap-app.ts
+++ b/scripts/build-bootstrap-app.ts
@@ -63,6 +63,31 @@ const compileOutputDirs = [path.join(distDir, "apps"), path.join(distDir, "packa
 
 const sleep = (delayMs: number) => new Promise<void>((resolve) => setTimeout(resolve, delayMs));
 
+const readFileWithRetries = async ({
+  filePath,
+  maxAttempts = 5,
+}: {
+  filePath: string;
+  maxAttempts?: number;
+}) => {
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      return await readFile(filePath, "utf8");
+    } catch (error) {
+      const code = (error as { code?: string } | null)?.code;
+      if (code !== "ENOENT" || attempt === maxAttempts - 1) {
+        throw error;
+      }
+
+      // Windows can briefly report freshly emitted TypeScript outputs as missing
+      // while the filesystem catches up. Back off and retry before failing tests.
+      await sleep(50 * (attempt + 1));
+    }
+  }
+
+  throw new Error(`Timed out reading ${filePath}.`);
+};
+
 const removeDirectoryWithRetries = async ({
   directory,
   maxAttempts = 8,
@@ -187,8 +212,8 @@ const loadBuildContext = async (): Promise<BuildContext> => {
   const compiledAppSourceDir = path.dirname(compiledTsEntryPath);
   const detectionPath = hasTsSource ? sourceTsPath : sourceJsPath;
   const compiledPath = hasTsSource ? compiledTsEntryPath : sourceJsPath;
-  const sourceCode = await readFile(detectionPath, "utf8");
-  const compiledSourceCode = await readFile(compiledPath, "utf8");
+  const sourceCode = await readFileWithRetries({ filePath: detectionPath });
+  const compiledSourceCode = await readFileWithRetries({ filePath: compiledPath });
 
   return {
     packageJson,

--- a/tests/unit/api-soft-delete-prisma.test.ts
+++ b/tests/unit/api-soft-delete-prisma.test.ts
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  addDefaultSoftDeleteWhere,
+  createSoftDeletePrismaClient,
+  normalizeSoftDeleteDeleteArgs,
+  normalizeSoftDeleteDeleteManyArgs,
+  normalizeSoftDeleteReadArgs,
+} from "../../apps/api/src/common/prisma/soft-delete.middleware.js";
+import {
+  createPrismaService,
+  withDeletedRecords,
+  withHardDeletes,
+} from "../../apps/api/src/common/prisma/prisma.service.js";
+
+const fixedDeletedAt = new Date("2026-04-24T12:00:00.000Z");
+const fixedNow = () => fixedDeletedAt;
+
+test("default read filter adds deletedAt null constraint when no override is used", () => {
+  assert.deepEqual(
+    addDefaultSoftDeleteWhere({
+      where: { workspaceId: "ws_123" },
+    }),
+    {
+      AND: [{ workspaceId: "ws_123" }, { deletedAt: null }],
+    },
+  );
+
+  assert.deepEqual(
+    normalizeSoftDeleteReadArgs({
+      args: {
+        where: { workspaceId: "ws_123" },
+      },
+    }),
+    {
+      where: {
+        AND: [{ workspaceId: "ws_123" }, { deletedAt: null }],
+      },
+    },
+  );
+});
+
+test("withDeleted override leaves read filters untouched for recovery flows", async () => {
+  let capturedArgs: unknown;
+  const baseClient = {
+    user: {
+      findMany: async (args?: unknown) => {
+        capturedArgs = args;
+        return [];
+      },
+    },
+  };
+
+  const prisma = createPrismaService(baseClient);
+
+  await withDeletedRecords(prisma).user.findMany({
+    where: {
+      deletedAt: {
+        not: null,
+      },
+    },
+  });
+
+  assert.deepEqual(capturedArgs, {
+    where: {
+      deletedAt: {
+        not: null,
+      },
+    },
+  });
+});
+
+test("soft delete normalizes delete operations into update payloads", () => {
+  assert.deepEqual(
+    normalizeSoftDeleteDeleteArgs({
+      args: {
+        where: { id: "user_123" },
+      },
+      now: fixedNow,
+    }),
+    {
+      where: { id: "user_123" },
+      data: {
+        deletedAt: fixedDeletedAt,
+      },
+    },
+  );
+
+  assert.deepEqual(
+    normalizeSoftDeleteDeleteManyArgs({
+      args: {
+        where: { workspaceId: "ws_123" },
+      },
+      now: fixedNow,
+    }),
+    {
+      where: {
+        AND: [{ workspaceId: "ws_123" }, { deletedAt: null }],
+      },
+      data: {
+        deletedAt: fixedDeletedAt,
+      },
+    },
+  );
+});
+
+test("default client turns delete and deleteMany into soft-delete updates", async () => {
+  const calls: Array<{ method: string; args: unknown }> = [];
+  const baseClient = {
+    user: {
+      update: async (args?: unknown) => {
+        calls.push({ method: "update", args });
+        return { id: "user_123" };
+      },
+      updateMany: async (args?: unknown) => {
+        calls.push({ method: "updateMany", args });
+        return { count: 1 };
+      },
+      delete: async (args?: unknown) => {
+        calls.push({ method: "delete", args });
+        return { id: "user_123" };
+      },
+      deleteMany: async (args?: unknown) => {
+        calls.push({ method: "deleteMany", args });
+        return { count: 1 };
+      },
+    },
+  };
+
+  const prisma = createSoftDeletePrismaClient(baseClient, {
+    now: fixedNow,
+  });
+
+  await prisma.user.delete({
+    where: { id: "user_123" },
+  });
+  await prisma.user.deleteMany({
+    where: { workspaceId: "ws_123" },
+  });
+
+  assert.deepEqual(calls, [
+    {
+      method: "update",
+      args: {
+        where: { id: "user_123" },
+        data: {
+          deletedAt: fixedDeletedAt,
+        },
+      },
+    },
+    {
+      method: "updateMany",
+      args: {
+        where: {
+          AND: [{ workspaceId: "ws_123" }, { deletedAt: null }],
+        },
+        data: {
+          deletedAt: fixedDeletedAt,
+        },
+      },
+    },
+  ]);
+});
+
+test("purge client keeps hard deletes available while default client still filters reads", async () => {
+  let defaultReadArgs: unknown;
+  let purgeDeleteArgs: unknown;
+  const baseClient = {
+    user: {
+      findMany: async (args?: unknown) => {
+        defaultReadArgs = args;
+        return [];
+      },
+      delete: async (args?: unknown) => {
+        purgeDeleteArgs = args;
+        return { id: "user_123" };
+      },
+    },
+    auditLog: {
+      findMany: async () => [],
+    },
+  };
+
+  const prisma = createPrismaService(baseClient);
+
+  await prisma.user.findMany({
+    where: { workspaceId: "ws_123" },
+  });
+  await withHardDeletes(prisma).user.delete({
+    where: { id: "user_123" },
+  });
+
+  assert.deepEqual(defaultReadArgs, {
+    where: {
+      AND: [{ workspaceId: "ws_123" }, { deletedAt: null }],
+    },
+  });
+  assert.deepEqual(purgeDeleteArgs, {
+    where: { id: "user_123" },
+  });
+});

--- a/tests/unit/api-soft-delete-prisma.test.ts
+++ b/tests/unit/api-soft-delete-prisma.test.ts
@@ -71,6 +71,39 @@ test("withDeleted override leaves read filters untouched for recovery flows", as
   });
 });
 
+test("findUnique delegates to findFirst so soft-delete filters stay valid", async () => {
+  const calls: Array<{ method: string; args: unknown }> = [];
+  const baseClient = {
+    user: {
+      findUnique: async (args?: unknown) => {
+        calls.push({ method: "findUnique", args });
+        return { id: "user_123" };
+      },
+      findFirst: async (args?: unknown) => {
+        calls.push({ method: "findFirst", args });
+        return { id: "user_123" };
+      },
+    },
+  };
+
+  const prisma = createPrismaService(baseClient);
+
+  await prisma.user.findUnique({
+    where: { id: "user_123" },
+  });
+
+  assert.deepEqual(calls, [
+    {
+      method: "findFirst",
+      args: {
+        where: {
+          AND: [{ id: "user_123" }, { deletedAt: null }],
+        },
+      },
+    },
+  ]);
+});
+
 test("soft delete normalizes delete operations into update payloads", () => {
   assert.deepEqual(
     normalizeSoftDeleteDeleteArgs({
@@ -198,5 +231,35 @@ test("purge client keeps hard deletes available while default client still filte
   });
   assert.deepEqual(purgeDeleteArgs, {
     where: { id: "user_123" },
+  });
+});
+
+test("withDeleted deleteMany still only targets active rows", async () => {
+  let updateManyArgs: unknown;
+  const baseClient = {
+    user: {
+      updateMany: async (args?: unknown) => {
+        updateManyArgs = args;
+        return { count: 1 };
+      },
+      deleteMany: async () => ({ count: 1 }),
+    },
+  };
+
+  const prisma = createSoftDeletePrismaClient(baseClient, {
+    now: fixedNow,
+  });
+
+  await prisma.$withDeleted().user.deleteMany({
+    where: { workspaceId: "ws_123" },
+  });
+
+  assert.deepEqual(updateManyArgs, {
+    where: {
+      AND: [{ workspaceId: "ws_123" }, { deletedAt: null }],
+    },
+    data: {
+      deletedAt: fixedDeletedAt,
+    },
   });
 });


### PR DESCRIPTION
## Linked Issue

Closes #41
Refs #309
Refs #310
Refs #311
Refs #312
Refs #313
Refs #314
Refs #1184

## Summary

- add an API-side Prisma soft-delete wrapper that filters deleted rows by default, exposes `prisma.$withDeleted()` for recovery flows, and keeps hard deletes behind `prisma.$withHardDeletes()` for purge-only workflows
- add API unit coverage for default filtering, explicit deleted-row access, and soft-delete interception of `delete` / `deleteMany`
- document the soft-delete contributor rules in `CONTRIBUTING.md` and serialize the TSX unit runner so the existing API bootstrap artifact tests stay stable under parallel test execution

## Validation

- [x] `pnpm prisma validate`
- [x] `pnpm --filter @collabsphere/api test`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test:unit`
- [x] `pnpm build`
- [x] `pnpm --filter @collabsphere/database exec prisma migrate diff --from-migrations prisma/migrations --to-schema-datamodel prisma/schema.prisma --shadow-database-url postgresql://collab:collab@127.0.0.1:55432/collabsphere_shadow --exit-code` (returned pre-existing migration-vs-datamodel drift outside this branch; no schema or migration files changed here)
- [ ] `pnpm review:coderabbit` (CLI failed before review because the repository/PR surface exceeds CodeRabbit's 150-file limit: reported 998 files)

## Risks / Notes

- CS-021 schema fields, `deleted_at` columns, and partial unique indexes were already present on `main` in `packages/database/prisma/schema.prisma` and `packages/database/prisma/migrations/20260423190000_initial_schema_creation/migration.sql`; this PR only closes the missing API/runtime/docs/test gap.
- The task template's `prisma migrate dev --dry-run` command is not supported by the pinned Prisma CLI in this repo, so `prisma migrate diff` against a local PostgreSQL 16 shadow database was used as the closest equivalent validation surface.
- The migration diff reports existing baseline drift in defaults / foreign keys / unsupported indexes between the tracked SQL migrations and Prisma datamodel rendering. That drift predates this branch and was not modified here.

## Handoff

- [x] Handoff added to the linked issue or parent story
- [ ] Handoff not required for this PR

## Handoff Summary

- API runtime now has a dedicated soft-delete Prisma wrapper and tests; contributor guidance records the required default-read, recovery, and purge conventions.

## Handoff Validation Evidence

- `pnpm prisma validate`
- `pnpm --filter @collabsphere/api test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm build`

## Handoff Open Issues / Follow-ups

- Local CodeRabbit review could not run because the CLI rejected the repo/PR surface as too large.
- Prisma migration diff still reports pre-existing baseline drift outside this PR's scope.

## Handoff Risks / Deviations

- none beyond the documented validation waivers above

## Review Guidance

- Relevant spec / agent-ref docs: `docs/spec/08-data-model/08.1-overview.md`, `docs/agent-ref/data/*.md`, `docs/agent-ref/rules/workspace-isolation.md`
- Areas that need extra scrutiny: default soft-delete filtering behavior in the new API wrapper, and the intentional use of lower-camel Prisma delegate keys (`prisma.user`, `prisma.workspace`, etc.)
