### PR TITLE
feat(api): implement CS-022 workspace scoping helpers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,15 @@ Examples:
 - `notification_type` remains a string key and must not be converted into a Prisma enum.
 - Do not introduce non-canonical enums without first updating the spec and agent-ref data contracts.
 
+## Workspace Scoping
+
+- Workspace-owned persistence tables must carry `workspace_id` and must be queried with explicit workspace scope.
+- The current workspace-owned table set is `workspace_members`, `workspace_settings`, `invitations`, `folders`, `documents`, `document_versions`, `document_submissions`, `task_columns`, `tasks`, `task_document_links`, `comment_threads`, `comments`, `comment_mentions`, `notifications`, `activity_events`, `export_jobs`, `files`, and `attachments`.
+- In the API layer, use `withWorkspaceScope(prisma, workspaceId)` from `apps/api/src/common/prisma/prisma.service.ts` for workspace-scoped Prisma access.
+- `withWorkspaceScope(...)` rejects missing `workspaceId`, injects `workspaceId` into workspace-scoped create payloads, preserves `$withDeleted()` / `$withHardDeletes()` chaining, and blocks cross-workspace writes.
+- Cross-workspace links remain invalid even when foreign keys are individually valid. Validate that related task, document, comment, file, and attachment records all belong to the same workspace before writing them.
+- Notifications may still use `workspace_id = null` for global user notifications. Only apply workspace scoping to notification queries that are explicitly workspace-owned.
+
 ## Issue Workflow
 
 ### Delivery lane

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,11 +181,11 @@ Examples:
 ## Workspace Scoping
 
 - Workspace-owned persistence tables must carry `workspace_id` and must be queried with explicit workspace scope.
-- The current workspace-owned table set is `workspace_members`, `workspace_settings`, `invitations`, `folders`, `documents`, `document_versions`, `document_submissions`, `task_columns`, `tasks`, `task_document_links`, `comment_threads`, `comments`, `comment_mentions`, `notifications`, `activity_events`, `export_jobs`, `files`, and `attachments`.
-- In the API layer, use `withWorkspaceScope(prisma, workspaceId)` from `apps/api/src/common/prisma/prisma.service.ts` for workspace-scoped Prisma access.
-- `withWorkspaceScope(...)` rejects missing `workspaceId`, injects `workspaceId` into workspace-scoped create payloads, preserves `$withDeleted()` / `$withHardDeletes()` chaining, and blocks cross-workspace writes.
+- The current workspace-owned table set is `workspace_members`, `workspace_settings`, `invitations`, `folders`, `documents`, `document_versions`, `document_submissions`, `task_columns`, `tasks`, `task_document_links`, `comment_threads`, `comments`, `comment_mentions`, `activity_events`, `export_jobs`, `files`, and `attachments`.
+- `notifications` is a mixed-scope table: workspace-owned notifications carry `workspace_id`, while global user notifications may use `workspace_id = null`.
+- In the API layer, use `withWorkspaceScope(prisma, workspaceId)` from `apps/api/src/common/prisma/prisma.service.ts` for workspace-scoped Prisma access, including notification queries that are explicitly workspace-owned.
+- `withWorkspaceScope(...)` rejects missing `workspaceId`, injects `workspaceId` into workspace-scoped create payloads, preserves `$withDeleted()` / `$withHardDeletes()` chaining, and rejects unsafe unique `update` / `delete` / `upsert` flows that Prisma cannot scope atomically.
 - Cross-workspace links remain invalid even when foreign keys are individually valid. Validate that related task, document, comment, file, and attachment records all belong to the same workspace before writing them.
-- Notifications may still use `workspace_id = null` for global user notifications. Only apply workspace scoping to notification queries that are explicitly workspace-owned.
 
 ## Issue Workflow
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,6 +6,6 @@
   "scripts": {
     "dev": "tsx watch src/dev.ts",
     "build": "pnpm exec tsc -p tsconfig.json && tsx ../../scripts/build-bootstrap-app.ts .",
-    "test": "pnpm exec tsx --test --test-concurrency=1 ../../tests/unit/api-bootstrap-env.test.ts ../../tests/unit/api-email-config.test.ts ../../tests/unit/api-soft-delete-prisma.test.ts"
+    "test": "pnpm exec tsx --test --test-concurrency=1 ../../tests/unit/api-bootstrap-env.test.ts ../../tests/unit/api-email-config.test.ts ../../tests/unit/api-soft-delete-prisma.test.ts ../../tests/unit/api-workspace-scope-prisma.test.ts"
   }
 }

--- a/apps/api/src/common/prisma/prisma-proxy.shared.ts
+++ b/apps/api/src/common/prisma/prisma-proxy.shared.ts
@@ -1,0 +1,107 @@
+export type RecordLike = Record<string | symbol, unknown>;
+export type UnknownFn = (...args: unknown[]) => unknown;
+
+export const isRecordLike = (value: unknown): value is RecordLike =>
+  typeof value === "object" && value !== null;
+
+export const isCallable = (value: unknown): value is UnknownFn =>
+  typeof value === "function";
+
+export const cloneArgs = (args: unknown): Record<string, unknown> => {
+  if (!isRecordLike(args)) {
+    return {};
+  }
+
+  return { ...(args as Record<string, unknown>) };
+};
+
+export const resolveRequiredDelegateMethod = ({
+  target,
+  receiver,
+  methodName,
+  errorMessage,
+}: {
+  target: object;
+  receiver: object;
+  methodName: string;
+  errorMessage: string;
+}) => {
+  const delegateMethod = Reflect.get(target, methodName, receiver);
+  if (!isCallable(delegateMethod)) {
+    throw new Error(errorMessage);
+  }
+
+  return delegateMethod;
+};
+
+export const createPassthroughHandler = ({
+  method,
+  target,
+}: {
+  method: (...args: unknown[]) => unknown;
+  target: object;
+}) =>
+  (...args: unknown[]) =>
+    Reflect.apply(method, target, args);
+
+export const createReadOperationHandler = ({
+  method,
+  target,
+  normalizeArgs,
+}: {
+  method: (...args: unknown[]) => unknown;
+  target: object;
+  normalizeArgs: (args: unknown) => Record<string, unknown>;
+}) =>
+  (args?: unknown) =>
+    Reflect.apply(method, target, [normalizeArgs(args)]);
+
+export const createUniqueReadOperationHandler = ({
+  target,
+  receiver,
+  methodName,
+  errorMessage,
+  normalizeArgs,
+}: {
+  target: object;
+  receiver: object;
+  methodName: string;
+  errorMessage: string;
+  normalizeArgs: (args: unknown) => Record<string, unknown>;
+}) =>
+  (args?: unknown) =>
+    Reflect.apply(
+      resolveRequiredDelegateMethod({
+        target,
+        receiver,
+        methodName,
+        errorMessage,
+      }),
+      target,
+      [normalizeArgs(args)],
+    );
+
+export const createMutationOperationHandler = ({
+  target,
+  receiver,
+  methodName,
+  errorMessage,
+  normalizeArgs,
+}: {
+  target: object;
+  receiver: object;
+  methodName: string;
+  errorMessage: string;
+  normalizeArgs: (args: unknown) => Record<string, unknown>;
+}) =>
+  (args?: unknown) =>
+    Reflect.apply(
+      resolveRequiredDelegateMethod({
+        target,
+        receiver,
+        methodName,
+        errorMessage,
+      }),
+      target,
+      [normalizeArgs(args)],
+    );

--- a/apps/api/src/common/prisma/prisma.service.ts
+++ b/apps/api/src/common/prisma/prisma.service.ts
@@ -2,6 +2,7 @@ import {
   createSoftDeletePrismaClient,
   type SoftDeleteClientControls,
 } from "./soft-delete.middleware.js";
+import { createWorkspaceScopedPrismaClient } from "./workspace-scope.js";
 
 export type PrismaService<TClient extends object> = TClient & SoftDeleteClientControls<TClient>;
 
@@ -13,3 +14,6 @@ export const withDeletedRecords = <TClient extends object>(client: PrismaService
 
 export const withHardDeletes = <TClient extends object>(client: PrismaService<TClient>) =>
   client.$withHardDeletes();
+
+export const withWorkspaceScope = <TClient extends object>(client: TClient, workspaceId: string) =>
+  createWorkspaceScopedPrismaClient(client, workspaceId);

--- a/apps/api/src/common/prisma/soft-delete.middleware.ts
+++ b/apps/api/src/common/prisma/soft-delete.middleware.ts
@@ -154,6 +154,9 @@ export const normalizeSoftDeleteDeleteArgs = ({
   normalizeSoftDeleteWriteArgs({
     args,
     now,
+    where: addDefaultSoftDeleteWhere({
+      where: cloneArgs(args).where,
+    }),
   });
 
 export const normalizeSoftDeleteDeleteManyArgs = ({

--- a/apps/api/src/common/prisma/soft-delete.middleware.ts
+++ b/apps/api/src/common/prisma/soft-delete.middleware.ts
@@ -6,7 +6,6 @@ import {
   createUniqueReadOperationHandler,
   isCallable,
   isRecordLike,
-  type RecordLike,
   type UnknownFn,
 } from "./prisma-proxy.shared.js";
 

--- a/apps/api/src/common/prisma/soft-delete.middleware.ts
+++ b/apps/api/src/common/prisma/soft-delete.middleware.ts
@@ -39,9 +39,10 @@ export const SOFT_DELETE_READ_OPERATIONS = [
   "groupBy",
 ] as const;
 
-export const SOFT_DELETE_DELEGATE_KEYS = SOFT_DELETE_MODELS.map((modelName) =>
-  modelName[0].toLowerCase() + modelName.slice(1),
-);
+export const SOFT_DELETE_DELEGATE_KEYS = SOFT_DELETE_MODELS.map((modelName) => {
+  const firstCharacter = modelName.charAt(0);
+  return firstCharacter.toLowerCase() + modelName.slice(1);
+});
 
 export type SoftDeleteProxyOptions = {
   includeDeleted?: boolean;
@@ -84,7 +85,7 @@ export const addDefaultSoftDeleteWhere = ({
     return { deletedAt: null };
   }
 
-  if ("deletedAt" in where) {
+  if (Object.hasOwn(where, "deletedAt")) {
     return where;
   }
 

--- a/apps/api/src/common/prisma/soft-delete.middleware.ts
+++ b/apps/api/src/common/prisma/soft-delete.middleware.ts
@@ -1,3 +1,15 @@
+import {
+  cloneArgs,
+  createMutationOperationHandler,
+  createPassthroughHandler,
+  createReadOperationHandler,
+  createUniqueReadOperationHandler,
+  isCallable,
+  isRecordLike,
+  type RecordLike,
+  type UnknownFn,
+} from "./prisma-proxy.shared.js";
+
 export const SOFT_DELETE_MODELS = [
   "User",
   "Workspace",
@@ -31,9 +43,6 @@ export const SOFT_DELETE_DELEGATE_KEYS = SOFT_DELETE_MODELS.map((modelName) =>
   modelName[0].toLowerCase() + modelName.slice(1),
 );
 
-type RecordLike = Record<string | symbol, unknown>;
-type UnknownFn = (...args: unknown[]) => unknown;
-
 export type SoftDeleteProxyOptions = {
   includeDeleted?: boolean;
   allowHardDelete?: boolean;
@@ -51,20 +60,6 @@ const UNIQUE_READ_OPERATION_MAP = {
   findUnique: "findFirst",
   findUniqueOrThrow: "findFirstOrThrow",
 } as const;
-
-const isRecordLike = (value: unknown): value is RecordLike =>
-  typeof value === "object" && value !== null;
-
-const isCallable = (value: unknown): value is UnknownFn =>
-  typeof value === "function";
-
-const cloneArgs = (args: unknown): Record<string, unknown> => {
-  if (!isRecordLike(args)) {
-    return {};
-  }
-
-  return { ...(args as Record<string, unknown>) };
-};
 
 const cloneData = (value: unknown) => {
   if (!isRecordLike(value)) {
@@ -176,105 +171,6 @@ export const normalizeSoftDeleteDeleteManyArgs = ({
     }),
   });
 
-const createReadOperationHandler = ({
-  method,
-  target,
-  includeDeleted,
-}: {
-  method: (...args: unknown[]) => unknown;
-  target: object;
-  includeDeleted?: boolean;
-}) =>
-  (args?: unknown) =>
-    Reflect.apply(method, target, [
-      normalizeSoftDeleteReadArgs({
-        args,
-        includeDeleted,
-      }),
-    ]);
-
-const resolveRequiredDelegateMethod = ({
-  target,
-  receiver,
-  methodName,
-  errorMessage,
-}: {
-  target: object;
-  receiver: object;
-  methodName: string;
-  errorMessage: string;
-}) => {
-  const delegateMethod = Reflect.get(target, methodName, receiver);
-  if (!isCallable(delegateMethod)) {
-    throw new Error(errorMessage);
-  }
-
-  return delegateMethod;
-};
-
-const createUniqueReadOperationHandler = ({
-  target,
-  receiver,
-  methodName,
-  includeDeleted,
-}: {
-  target: object;
-  receiver: object;
-  methodName: "findFirst" | "findFirstOrThrow";
-  includeDeleted?: boolean;
-}) =>
-  (args?: unknown) =>
-    Reflect.apply(
-      resolveRequiredDelegateMethod({
-        target,
-        receiver,
-        methodName,
-        errorMessage: `Soft delete proxy requires a ${methodName}() delegate method.`,
-      }),
-      target,
-      [
-        normalizeSoftDeleteReadArgs({
-          args,
-          includeDeleted,
-        }),
-      ],
-    );
-
-const createMutationOperationHandler = ({
-  target,
-  receiver,
-  methodName,
-  errorMessage,
-  normalizeArgs,
-}: {
-  target: object;
-  receiver: object;
-  methodName: "update" | "updateMany";
-  errorMessage: string;
-  normalizeArgs: (args: unknown) => Record<string, unknown>;
-}) =>
-  (args?: unknown) =>
-    Reflect.apply(
-      resolveRequiredDelegateMethod({
-        target,
-        receiver,
-        methodName,
-        errorMessage,
-      }),
-      target,
-      [normalizeArgs(args)],
-    );
-
-const createPassthroughHandler = ({
-  method,
-  target,
-}: {
-  method: (...args: unknown[]) => unknown;
-  target: object;
-}) =>
-  (...args: unknown[]) =>
-    Reflect.apply(method, target, args);
-
 const resolveReadOperationHandler = ({
   property,
   target,
@@ -293,7 +189,12 @@ const resolveReadOperationHandler = ({
       target,
       receiver,
       methodName: UNIQUE_READ_OPERATION_MAP[property],
-      includeDeleted: options.includeDeleted,
+      errorMessage: `Soft delete proxy requires a ${UNIQUE_READ_OPERATION_MAP[property]}() delegate method.`,
+      normalizeArgs: (args) =>
+        normalizeSoftDeleteReadArgs({
+          args,
+          includeDeleted: options.includeDeleted,
+        }),
     });
   }
 
@@ -301,7 +202,11 @@ const resolveReadOperationHandler = ({
     return createReadOperationHandler({
       method: value,
       target,
-      includeDeleted: options.includeDeleted,
+      normalizeArgs: (args) =>
+        normalizeSoftDeleteReadArgs({
+          args,
+          includeDeleted: options.includeDeleted,
+        }),
     });
   }
 

--- a/apps/api/src/common/prisma/workspace-scope.ts
+++ b/apps/api/src/common/prisma/workspace-scope.ts
@@ -6,7 +6,6 @@ import {
   createUniqueReadOperationHandler,
   isCallable,
   isRecordLike,
-  resolveRequiredDelegateMethod,
   type RecordLike,
   type UnknownFn,
 } from "./prisma-proxy.shared.js";
@@ -56,6 +55,8 @@ const UNIQUE_READ_OPERATION_MAP = {
 export const MISSING_WORKSPACE_SCOPE_ERROR =
   "workspaceId is required for workspace-scoped Prisma access.";
 export const CROSS_WORKSPACE_WRITE_ERROR = "Cross-workspace writes are not allowed.";
+export const UNSUPPORTED_WORKSPACE_UNIQUE_MUTATION_ERROR =
+  "Workspace-scoped update() and delete() are not supported; use workspace-scoped updateMany()/deleteMany() or an explicit read + conditional write flow.";
 export const UNSUPPORTED_WORKSPACE_UPSERT_ERROR =
   "Workspace-scoped upsert is not supported; split it into explicit read/create or read/update flows.";
 
@@ -106,18 +107,31 @@ export const addWorkspaceScopeWhere = ({
   };
 };
 
-const normalizeWorkspaceCreateData = ({
+const normalizeWorkspaceWriteData = ({
   workspaceId,
   data,
+  stripWorkspaceId = false,
 }: {
   workspaceId: string;
   data: unknown;
+  stripWorkspaceId?: boolean;
 }) => {
   const normalizedWorkspaceId = requireWorkspaceId(workspaceId);
   const nextData = cloneData(data);
 
-  if ("workspaceId" in nextData && nextData.workspaceId !== normalizedWorkspaceId) {
+  const providedWorkspaceId = "workspaceId" in nextData ? nextData.workspaceId : undefined;
+
+  if (
+    providedWorkspaceId !== undefined &&
+    providedWorkspaceId !== null &&
+    providedWorkspaceId !== normalizedWorkspaceId
+  ) {
     throw new Error(CROSS_WORKSPACE_WRITE_ERROR);
+  }
+
+  if (stripWorkspaceId) {
+    delete nextData.workspaceId;
+    return nextData;
   }
 
   return {
@@ -135,14 +149,14 @@ const normalizeWorkspaceCreateManyData = ({
 }) => {
   if (Array.isArray(data)) {
     return data.map((entry) =>
-      normalizeWorkspaceCreateData({
+      normalizeWorkspaceWriteData({
         workspaceId,
         data: entry,
       }),
     );
   }
 
-  return normalizeWorkspaceCreateData({
+  return normalizeWorkspaceWriteData({
     workspaceId,
     data,
   });
@@ -155,14 +169,41 @@ const normalizeWorkspaceUpdateData = ({
   workspaceId: string;
   data: unknown;
 }) => {
-  const normalizedWorkspaceId = requireWorkspaceId(workspaceId);
-  const nextData = cloneData(data);
+  return normalizeWorkspaceWriteData({
+    workspaceId,
+    data,
+    stripWorkspaceId: true,
+  });
+};
 
-  if ("workspaceId" in nextData && nextData.workspaceId !== normalizedWorkspaceId) {
-    throw new Error(CROSS_WORKSPACE_WRITE_ERROR);
+const normalizeWorkspaceScopedArgs = ({
+  workspaceId,
+  args,
+  scopeWhere = false,
+  normalizeData,
+}: {
+  workspaceId: string;
+  args: unknown;
+  scopeWhere?: boolean;
+  normalizeData?: (payload: { workspaceId: string; data: unknown }) => unknown;
+}) => {
+  const nextArgs = cloneArgs(args);
+
+  if (scopeWhere) {
+    nextArgs.where = addWorkspaceScopeWhere({
+      workspaceId,
+      where: nextArgs.where,
+    });
   }
 
-  return nextData;
+  if (normalizeData) {
+    nextArgs.data = normalizeData({
+      workspaceId,
+      data: nextArgs.data,
+    });
+  }
+
+  return nextArgs;
 };
 
 export const normalizeWorkspaceScopedReadArgs = ({
@@ -171,16 +212,12 @@ export const normalizeWorkspaceScopedReadArgs = ({
 }: {
   workspaceId: string;
   args: unknown;
-}) => {
-  const nextArgs = cloneArgs(args);
-
-  nextArgs.where = addWorkspaceScopeWhere({
+}) =>
+  normalizeWorkspaceScopedArgs({
     workspaceId,
-    where: nextArgs.where,
+    args,
+    scopeWhere: true,
   });
-
-  return nextArgs;
-};
 
 export const normalizeWorkspaceScopedCreateArgs = ({
   workspaceId,
@@ -188,16 +225,12 @@ export const normalizeWorkspaceScopedCreateArgs = ({
 }: {
   workspaceId: string;
   args: unknown;
-}) => {
-  const nextArgs = cloneArgs(args);
-
-  nextArgs.data = normalizeWorkspaceCreateData({
+}) =>
+  normalizeWorkspaceScopedArgs({
     workspaceId,
-    data: nextArgs.data,
+    args,
+    normalizeData: normalizeWorkspaceWriteData,
   });
-
-  return nextArgs;
-};
 
 export const normalizeWorkspaceScopedCreateManyArgs = ({
   workspaceId,
@@ -205,16 +238,16 @@ export const normalizeWorkspaceScopedCreateManyArgs = ({
 }: {
   workspaceId: string;
   args: unknown;
-}) => {
-  const nextArgs = cloneArgs(args);
-
-  nextArgs.data = normalizeWorkspaceCreateManyData({
+}) =>
+  normalizeWorkspaceScopedArgs({
     workspaceId,
-    data: nextArgs.data,
+    args,
+    normalizeData: ({ workspaceId: nextWorkspaceId, data }) =>
+      normalizeWorkspaceCreateManyData({
+        workspaceId: nextWorkspaceId,
+        data,
+      }),
   });
-
-  return nextArgs;
-};
 
 export const normalizeWorkspaceScopedUpdateManyArgs = ({
   workspaceId,
@@ -222,91 +255,17 @@ export const normalizeWorkspaceScopedUpdateManyArgs = ({
 }: {
   workspaceId: string;
   args: unknown;
-}) => {
-  const nextArgs = cloneArgs(args);
-
-  nextArgs.where = addWorkspaceScopeWhere({
-    workspaceId,
-    where: nextArgs.where,
-  });
-  if ("data" in nextArgs) {
-    nextArgs.data = normalizeWorkspaceUpdateData({
-      workspaceId,
-      data: nextArgs.data,
-    });
-  }
-
-  return nextArgs;
-};
-
-const normalizeWorkspaceScopedUpdateArgs = ({
-  workspaceId,
-  args,
-}: {
-  workspaceId: string;
-  args: unknown;
-}) => {
-  const nextArgs = cloneArgs(args);
-
-  if ("data" in nextArgs) {
-    nextArgs.data = normalizeWorkspaceUpdateData({
-      workspaceId,
-      data: nextArgs.data,
-    });
-  }
-
-  return nextArgs;
-};
-
-const createGuardedUniqueMutationHandler = ({
-  property,
-  target,
-  receiver,
-  workspaceId,
-  normalizeArgs,
-}: {
-  property: "update" | "delete";
-  target: object;
-  receiver: object;
-  workspaceId: string;
-  normalizeArgs: (args: unknown) => Record<string, unknown>;
 }) =>
-  async (args?: unknown) => {
-    const nextArgs = cloneArgs(args);
-    const findFirst = resolveRequiredDelegateMethod({
-      target,
-      receiver,
-      methodName: "findFirst",
-      errorMessage: "Workspace scope proxy requires a findFirst() delegate method for unique mutations.",
-    });
+  normalizeWorkspaceScopedArgs({
+    workspaceId,
+    args,
+    scopeWhere: true,
+    normalizeData: normalizeWorkspaceUpdateData,
+  });
 
-    const record = await Reflect.apply(findFirst, target, [
-      {
-        where: addWorkspaceScopeWhere({
-          workspaceId,
-          where: nextArgs.where,
-        }),
-        select: { id: true },
-      },
-    ]);
-
-    if (!record) {
-      throw new Error(
-        `Workspace-scoped ${property}() did not match an active record in workspace ${requireWorkspaceId(workspaceId)}.`,
-      );
-    }
-
-    return Reflect.apply(
-      resolveRequiredDelegateMethod({
-        target,
-        receiver,
-        methodName: property,
-        errorMessage: `Workspace scope proxy requires a ${property}() delegate method.`,
-      }),
-      target,
-      [normalizeArgs(nextArgs)],
-    );
-  };
+const createUnsupportedWorkspaceMutationHandler = (message: string) => () => {
+  throw new Error(message);
+};
 
 const resolveReadOperationHandler = ({
   property,
@@ -385,23 +344,15 @@ const resolveWriteOperationHandler = ({
   }
 
   if (property === "update" || property === "delete") {
-    return createGuardedUniqueMutationHandler({
-      property,
-      target,
-      receiver,
-      workspaceId,
-      normalizeArgs: (args) =>
-        normalizeWorkspaceScopedUpdateArgs({
-          workspaceId,
-          args,
-        }),
-    });
+    return createUnsupportedWorkspaceMutationHandler(
+      UNSUPPORTED_WORKSPACE_UNIQUE_MUTATION_ERROR,
+    );
   }
 
   if (property === "upsert") {
-    return () => {
-      throw new Error(UNSUPPORTED_WORKSPACE_UPSERT_ERROR);
-    };
+    return createUnsupportedWorkspaceMutationHandler(
+      UNSUPPORTED_WORKSPACE_UPSERT_ERROR,
+    );
   }
 
   return null;

--- a/apps/api/src/common/prisma/workspace-scope.ts
+++ b/apps/api/src/common/prisma/workspace-scope.ts
@@ -110,12 +110,22 @@ export const addWorkspaceScopeWhere = ({
 const normalizeWorkspaceWriteData = ({
   workspaceId,
   data,
-  stripWorkspaceId = false,
+  mode,
 }: {
   workspaceId: string;
   data: unknown;
-  stripWorkspaceId?: boolean;
-}) => {
+  mode: "create" | "update";
+}): unknown => {
+  if (Array.isArray(data)) {
+    return data.map((entry) =>
+      normalizeWorkspaceWriteData({
+        workspaceId,
+        data: entry,
+        mode,
+      }),
+    );
+  }
+
   const normalizedWorkspaceId = requireWorkspaceId(workspaceId);
   const nextData = cloneData(data);
 
@@ -129,7 +139,7 @@ const normalizeWorkspaceWriteData = ({
     throw new Error(CROSS_WORKSPACE_WRITE_ERROR);
   }
 
-  if (stripWorkspaceId) {
+  if (mode === "update") {
     delete nextData.workspaceId;
     return nextData;
   }
@@ -140,128 +150,41 @@ const normalizeWorkspaceWriteData = ({
   };
 };
 
-const normalizeWorkspaceCreateManyData = ({
-  workspaceId,
-  data,
-}: {
-  workspaceId: string;
-  data: unknown;
-}) => {
-  if (Array.isArray(data)) {
-    return data.map((entry) =>
-      normalizeWorkspaceWriteData({
-        workspaceId,
-        data: entry,
-      }),
-    );
-  }
-
-  return normalizeWorkspaceWriteData({
-    workspaceId,
-    data,
-  });
-};
-
-const normalizeWorkspaceUpdateData = ({
-  workspaceId,
-  data,
-}: {
-  workspaceId: string;
-  data: unknown;
-}) => {
-  return normalizeWorkspaceWriteData({
-    workspaceId,
-    data,
-    stripWorkspaceId: true,
-  });
-};
-
-const normalizeWorkspaceScopedArgs = ({
+export const normalizeWorkspaceScopedArgs = ({
   workspaceId,
   args,
-  scopeWhere = false,
-  normalizeData,
+  operation,
 }: {
   workspaceId: string;
   args: unknown;
-  scopeWhere?: boolean;
-  normalizeData?: (payload: { workspaceId: string; data: unknown }) => unknown;
+  operation: "read" | "create" | "createMany" | "updateMany" | "deleteMany";
 }) => {
+  const operationConfig = {
+    read: { scopeWhere: true },
+    create: { normalizeMode: "create" as const },
+    createMany: { normalizeMode: "create" as const },
+    updateMany: { scopeWhere: true, normalizeMode: "update" as const },
+    deleteMany: { scopeWhere: true, normalizeMode: "update" as const },
+  }[operation];
   const nextArgs = cloneArgs(args);
 
-  if (scopeWhere) {
+  if (operationConfig.scopeWhere) {
     nextArgs.where = addWorkspaceScopeWhere({
       workspaceId,
       where: nextArgs.where,
     });
   }
 
-  if (normalizeData) {
-    nextArgs.data = normalizeData({
+  if (operationConfig.normalizeMode) {
+    nextArgs.data = normalizeWorkspaceWriteData({
       workspaceId,
       data: nextArgs.data,
+      mode: operationConfig.normalizeMode,
     });
   }
 
   return nextArgs;
 };
-
-export const normalizeWorkspaceScopedReadArgs = ({
-  workspaceId,
-  args,
-}: {
-  workspaceId: string;
-  args: unknown;
-}) =>
-  normalizeWorkspaceScopedArgs({
-    workspaceId,
-    args,
-    scopeWhere: true,
-  });
-
-export const normalizeWorkspaceScopedCreateArgs = ({
-  workspaceId,
-  args,
-}: {
-  workspaceId: string;
-  args: unknown;
-}) =>
-  normalizeWorkspaceScopedArgs({
-    workspaceId,
-    args,
-    normalizeData: normalizeWorkspaceWriteData,
-  });
-
-export const normalizeWorkspaceScopedCreateManyArgs = ({
-  workspaceId,
-  args,
-}: {
-  workspaceId: string;
-  args: unknown;
-}) =>
-  normalizeWorkspaceScopedArgs({
-    workspaceId,
-    args,
-    normalizeData: ({ workspaceId: nextWorkspaceId, data }) =>
-      normalizeWorkspaceCreateManyData({
-        workspaceId: nextWorkspaceId,
-        data,
-      }),
-  });
-
-export const normalizeWorkspaceScopedUpdateManyArgs = ({
-  workspaceId,
-  args,
-}: {
-  workspaceId: string;
-  args: unknown;
-}) =>
-  normalizeWorkspaceScopedArgs({
-    workspaceId,
-    args,
-    scopeWhere: true,
-    normalizeData: normalizeWorkspaceUpdateData,
-  });
 
 const createUnsupportedWorkspaceMutationHandler = (message: string) => () => {
   throw new Error(message);
@@ -287,9 +210,10 @@ const resolveReadOperationHandler = ({
       methodName: UNIQUE_READ_OPERATION_MAP[property],
       errorMessage: `Workspace scope proxy requires a ${UNIQUE_READ_OPERATION_MAP[property]}() delegate method.`,
       normalizeArgs: (args) =>
-        normalizeWorkspaceScopedReadArgs({
+        normalizeWorkspaceScopedArgs({
           workspaceId,
           args,
+          operation: "read",
         }),
     });
   }
@@ -299,9 +223,10 @@ const resolveReadOperationHandler = ({
       method: value,
       target,
       normalizeArgs: (args) =>
-        normalizeWorkspaceScopedReadArgs({
+        normalizeWorkspaceScopedArgs({
           workspaceId,
           args,
+          operation: "read",
         }),
     });
   }
@@ -320,15 +245,15 @@ const resolveWriteOperationHandler = ({
   receiver: object;
   workspaceId: string;
 }) => {
-  const bulkMutationNormalizers = {
-    create: normalizeWorkspaceScopedCreateArgs,
-    createMany: normalizeWorkspaceScopedCreateManyArgs,
-    updateMany: normalizeWorkspaceScopedUpdateManyArgs,
-    deleteMany: normalizeWorkspaceScopedUpdateManyArgs,
+  const bulkMutationOperations = {
+    create: "create",
+    createMany: "createMany",
+    updateMany: "updateMany",
+    deleteMany: "deleteMany",
   } as const;
 
-  if (property in bulkMutationNormalizers) {
-    const normalizeArgs = bulkMutationNormalizers[property as keyof typeof bulkMutationNormalizers];
+  if (property in bulkMutationOperations) {
+    const operation = bulkMutationOperations[property as keyof typeof bulkMutationOperations];
 
     return createMutationOperationHandler({
       target,
@@ -336,9 +261,10 @@ const resolveWriteOperationHandler = ({
       methodName: property,
       errorMessage: `Workspace scope proxy requires a ${property}() delegate method.`,
       normalizeArgs: (args) =>
-        normalizeArgs({
+        normalizeWorkspaceScopedArgs({
           workspaceId,
           args,
+          operation,
         }),
     });
   }

--- a/apps/api/src/common/prisma/workspace-scope.ts
+++ b/apps/api/src/common/prisma/workspace-scope.ts
@@ -1,3 +1,16 @@
+import {
+  cloneArgs,
+  createMutationOperationHandler,
+  createPassthroughHandler,
+  createReadOperationHandler,
+  createUniqueReadOperationHandler,
+  isCallable,
+  isRecordLike,
+  resolveRequiredDelegateMethod,
+  type RecordLike,
+  type UnknownFn,
+} from "./prisma-proxy.shared.js";
+
 const WORKSPACE_SCOPED_MODELS = [
   "workspaceMember",
   "workspaceSettings",
@@ -32,9 +45,6 @@ const WORKSPACE_SCOPED_READ_OPERATIONS = [
 
 const WORKSPACE_SCOPED_CLIENT_CONTROLS = ["$withDeleted", "$withHardDeletes"] as const;
 
-type RecordLike = Record<string | symbol, unknown>;
-type UnknownFn = (...args: unknown[]) => unknown;
-
 const WORKSPACE_SCOPED_MODEL_SET = new Set<string>(WORKSPACE_SCOPED_MODELS);
 const WORKSPACE_SCOPED_READ_OPERATION_SET = new Set<string>(WORKSPACE_SCOPED_READ_OPERATIONS);
 const WORKSPACE_SCOPED_CLIENT_CONTROL_SET = new Set<string>(WORKSPACE_SCOPED_CLIENT_CONTROLS);
@@ -48,20 +58,6 @@ export const MISSING_WORKSPACE_SCOPE_ERROR =
 export const CROSS_WORKSPACE_WRITE_ERROR = "Cross-workspace writes are not allowed.";
 export const UNSUPPORTED_WORKSPACE_UPSERT_ERROR =
   "Workspace-scoped upsert is not supported; split it into explicit read/create or read/update flows.";
-
-const isRecordLike = (value: unknown): value is RecordLike =>
-  typeof value === "object" && value !== null;
-
-const isCallable = (value: unknown): value is UnknownFn =>
-  typeof value === "function";
-
-const cloneArgs = (args: unknown): Record<string, unknown> => {
-  if (!isRecordLike(args)) {
-    return {};
-  }
-
-  return { ...(args as Record<string, unknown>) };
-};
 
 const cloneData = (value: unknown) => {
   if (!isRecordLike(value)) {
@@ -262,105 +258,6 @@ const normalizeWorkspaceScopedUpdateArgs = ({
   return nextArgs;
 };
 
-const resolveRequiredDelegateMethod = ({
-  target,
-  receiver,
-  methodName,
-  errorMessage,
-}: {
-  target: object;
-  receiver: object;
-  methodName: string;
-  errorMessage: string;
-}) => {
-  const delegateMethod = Reflect.get(target, methodName, receiver);
-  if (!isCallable(delegateMethod)) {
-    throw new Error(errorMessage);
-  }
-
-  return delegateMethod;
-};
-
-const createPassthroughHandler = ({
-  method,
-  target,
-}: {
-  method: (...args: unknown[]) => unknown;
-  target: object;
-}) =>
-  (...args: unknown[]) =>
-    Reflect.apply(method, target, args);
-
-const createReadOperationHandler = ({
-  method,
-  target,
-  workspaceId,
-}: {
-  method: (...args: unknown[]) => unknown;
-  target: object;
-  workspaceId: string;
-}) =>
-  (args?: unknown) =>
-    Reflect.apply(method, target, [
-      normalizeWorkspaceScopedReadArgs({
-        workspaceId,
-        args,
-      }),
-    ]);
-
-const createUniqueReadOperationHandler = ({
-  target,
-  receiver,
-  methodName,
-  workspaceId,
-}: {
-  target: object;
-  receiver: object;
-  methodName: "findFirst" | "findFirstOrThrow";
-  workspaceId: string;
-}) =>
-  (args?: unknown) =>
-    Reflect.apply(
-      resolveRequiredDelegateMethod({
-        target,
-        receiver,
-        methodName,
-        errorMessage: `Workspace scope proxy requires a ${methodName}() delegate method.`,
-      }),
-      target,
-      [
-        normalizeWorkspaceScopedReadArgs({
-          workspaceId,
-          args,
-        }),
-      ],
-    );
-
-const createMutationOperationHandler = ({
-  target,
-  receiver,
-  methodName,
-  errorMessage,
-  normalizeArgs,
-}: {
-  target: object;
-  receiver: object;
-  methodName: string;
-  errorMessage: string;
-  normalizeArgs: (args: unknown) => Record<string, unknown>;
-}) =>
-  (args?: unknown) =>
-    Reflect.apply(
-      resolveRequiredDelegateMethod({
-        target,
-        receiver,
-        methodName,
-        errorMessage,
-      }),
-      target,
-      [normalizeArgs(args)],
-    );
-
 const createGuardedUniqueMutationHandler = ({
   property,
   target,
@@ -429,7 +326,12 @@ const resolveReadOperationHandler = ({
       target,
       receiver,
       methodName: UNIQUE_READ_OPERATION_MAP[property],
-      workspaceId,
+      errorMessage: `Workspace scope proxy requires a ${UNIQUE_READ_OPERATION_MAP[property]}() delegate method.`,
+      normalizeArgs: (args) =>
+        normalizeWorkspaceScopedReadArgs({
+          workspaceId,
+          args,
+        }),
     });
   }
 
@@ -437,7 +339,11 @@ const resolveReadOperationHandler = ({
     return createReadOperationHandler({
       method: value,
       target,
-      workspaceId,
+      normalizeArgs: (args) =>
+        normalizeWorkspaceScopedReadArgs({
+          workspaceId,
+          args,
+        }),
     });
   }
 
@@ -455,42 +361,23 @@ const resolveWriteOperationHandler = ({
   receiver: object;
   workspaceId: string;
 }) => {
-  if (property === "create") {
-    return createMutationOperationHandler({
-      target,
-      receiver,
-      methodName: "create",
-      errorMessage: "Workspace scope proxy requires a create() delegate method.",
-      normalizeArgs: (args) =>
-        normalizeWorkspaceScopedCreateArgs({
-          workspaceId,
-          args,
-        }),
-    });
-  }
+  const bulkMutationNormalizers = {
+    create: normalizeWorkspaceScopedCreateArgs,
+    createMany: normalizeWorkspaceScopedCreateManyArgs,
+    updateMany: normalizeWorkspaceScopedUpdateManyArgs,
+    deleteMany: normalizeWorkspaceScopedUpdateManyArgs,
+  } as const;
 
-  if (property === "createMany") {
-    return createMutationOperationHandler({
-      target,
-      receiver,
-      methodName: "createMany",
-      errorMessage: "Workspace scope proxy requires a createMany() delegate method.",
-      normalizeArgs: (args) =>
-        normalizeWorkspaceScopedCreateManyArgs({
-          workspaceId,
-          args,
-        }),
-    });
-  }
+  if (property in bulkMutationNormalizers) {
+    const normalizeArgs = bulkMutationNormalizers[property as keyof typeof bulkMutationNormalizers];
 
-  if (property === "updateMany" || property === "deleteMany") {
     return createMutationOperationHandler({
       target,
       receiver,
       methodName: property,
       errorMessage: `Workspace scope proxy requires a ${property}() delegate method.`,
       normalizeArgs: (args) =>
-        normalizeWorkspaceScopedUpdateManyArgs({
+        normalizeArgs({
           workspaceId,
           args,
         }),

--- a/apps/api/src/common/prisma/workspace-scope.ts
+++ b/apps/api/src/common/prisma/workspace-scope.ts
@@ -6,7 +6,6 @@ import {
   createUniqueReadOperationHandler,
   isCallable,
   isRecordLike,
-  type RecordLike,
   type UnknownFn,
 } from "./prisma-proxy.shared.js";
 

--- a/apps/api/src/common/prisma/workspace-scope.ts
+++ b/apps/api/src/common/prisma/workspace-scope.ts
@@ -68,6 +68,17 @@ const cloneData = (value: unknown) => {
   return { ...(value as Record<string, unknown>) };
 };
 
+const hasConflictingWorkspaceId = ({
+  expectedWorkspaceId,
+  actualWorkspaceId,
+}: {
+  expectedWorkspaceId: string;
+  actualWorkspaceId: unknown;
+}) =>
+  actualWorkspaceId !== undefined &&
+  actualWorkspaceId !== null &&
+  actualWorkspaceId !== expectedWorkspaceId;
+
 export const requireWorkspaceId = (workspaceId: string) => {
   const normalizedWorkspaceId = workspaceId.trim();
   if (normalizedWorkspaceId.length === 0) {
@@ -132,9 +143,10 @@ const normalizeWorkspaceWriteData = ({
   const providedWorkspaceId = "workspaceId" in nextData ? nextData.workspaceId : undefined;
 
   if (
-    providedWorkspaceId !== undefined &&
-    providedWorkspaceId !== null &&
-    providedWorkspaceId !== normalizedWorkspaceId
+    hasConflictingWorkspaceId({
+      expectedWorkspaceId: normalizedWorkspaceId,
+      actualWorkspaceId: providedWorkspaceId,
+    })
   ) {
     throw new Error(CROSS_WORKSPACE_WRITE_ERROR);
   }
@@ -159,31 +171,41 @@ export const normalizeWorkspaceScopedArgs = ({
   args: unknown;
   operation: "read" | "create" | "createMany" | "updateMany" | "deleteMany";
 }) => {
-  const operationConfig = {
-    read: { scopeWhere: true },
-    create: { normalizeMode: "create" as const },
-    createMany: { normalizeMode: "create" as const },
-    updateMany: { scopeWhere: true, normalizeMode: "update" as const },
-    deleteMany: { scopeWhere: true, normalizeMode: "update" as const },
-  }[operation];
   const nextArgs = cloneArgs(args);
 
-  if (operationConfig.scopeWhere) {
-    nextArgs.where = addWorkspaceScopeWhere({
-      workspaceId,
-      where: nextArgs.where,
-    });
+  switch (operation) {
+    case "read":
+    case "deleteMany":
+      nextArgs.where = addWorkspaceScopeWhere({
+        workspaceId,
+        where: nextArgs.where,
+      });
+      return nextArgs;
+
+    case "updateMany":
+      nextArgs.where = addWorkspaceScopeWhere({
+        workspaceId,
+        where: nextArgs.where,
+      });
+      nextArgs.data = normalizeWorkspaceWriteData({
+        workspaceId,
+        data: nextArgs.data,
+        mode: "update",
+      });
+      return nextArgs;
+
+    case "create":
+    case "createMany":
+      nextArgs.data = normalizeWorkspaceWriteData({
+        workspaceId,
+        data: nextArgs.data,
+        mode: "create",
+      });
+      return nextArgs;
   }
 
-  if (operationConfig.normalizeMode) {
-    nextArgs.data = normalizeWorkspaceWriteData({
-      workspaceId,
-      data: nextArgs.data,
-      mode: operationConfig.normalizeMode,
-    });
-  }
-
-  return nextArgs;
+  const unsupportedOperation: never = operation;
+  return unsupportedOperation;
 };
 
 const createUnsupportedWorkspaceMutationHandler = (message: string) => () => {

--- a/apps/api/src/common/prisma/workspace-scope.ts
+++ b/apps/api/src/common/prisma/workspace-scope.ts
@@ -140,7 +140,9 @@ const normalizeWorkspaceWriteData = ({
   const normalizedWorkspaceId = requireWorkspaceId(workspaceId);
   const nextData = cloneData(data);
 
-  const providedWorkspaceId = "workspaceId" in nextData ? nextData.workspaceId : undefined;
+  const providedWorkspaceId = Object.hasOwn(nextData, "workspaceId")
+    ? nextData.workspaceId
+    : undefined;
 
   if (
     hasConflictingWorkspaceId({
@@ -274,7 +276,7 @@ const resolveWriteOperationHandler = ({
     deleteMany: "deleteMany",
   } as const;
 
-  if (property in bulkMutationOperations) {
+  if (Object.hasOwn(bulkMutationOperations, property)) {
     const operation = bulkMutationOperations[property as keyof typeof bulkMutationOperations];
 
     return createMutationOperationHandler({

--- a/apps/api/src/common/prisma/workspace-scope.ts
+++ b/apps/api/src/common/prisma/workspace-scope.ts
@@ -10,7 +10,7 @@ import {
   type UnknownFn,
 } from "./prisma-proxy.shared.js";
 
-const WORKSPACE_SCOPED_MODELS = [
+export const WORKSPACE_SCOPED_MODELS = [
   "workspaceMember",
   "workspaceSettings",
   "invitation",
@@ -29,6 +29,26 @@ const WORKSPACE_SCOPED_MODELS = [
   "exportJob",
   "file",
   "attachment",
+] as const;
+
+export const WORKSPACE_SCOPED_TABLES = [
+  "workspace_members",
+  "workspace_settings",
+  "invitations",
+  "folders",
+  "documents",
+  "document_versions",
+  "document_submissions",
+  "task_columns",
+  "tasks",
+  "task_document_links",
+  "comment_threads",
+  "comments",
+  "comment_mentions",
+  "activity_events",
+  "export_jobs",
+  "files",
+  "attachments",
 ] as const;
 
 const WORKSPACE_SCOPED_READ_OPERATIONS = [

--- a/apps/api/src/common/prisma/workspace-scope.ts
+++ b/apps/api/src/common/prisma/workspace-scope.ts
@@ -1,0 +1,617 @@
+const WORKSPACE_SCOPED_MODELS = [
+  "workspaceMember",
+  "workspaceSettings",
+  "invitation",
+  "folder",
+  "document",
+  "documentVersion",
+  "documentSubmission",
+  "taskColumn",
+  "task",
+  "taskDocumentLink",
+  "commentThread",
+  "comment",
+  "commentMention",
+  "notification",
+  "activityEvent",
+  "exportJob",
+  "file",
+  "attachment",
+] as const;
+
+const WORKSPACE_SCOPED_READ_OPERATIONS = [
+  "findUnique",
+  "findUniqueOrThrow",
+  "findFirst",
+  "findFirstOrThrow",
+  "findMany",
+  "count",
+  "aggregate",
+  "groupBy",
+] as const;
+
+const WORKSPACE_SCOPED_CLIENT_CONTROLS = ["$withDeleted", "$withHardDeletes"] as const;
+
+type RecordLike = Record<string | symbol, unknown>;
+type UnknownFn = (...args: unknown[]) => unknown;
+
+const WORKSPACE_SCOPED_MODEL_SET = new Set<string>(WORKSPACE_SCOPED_MODELS);
+const WORKSPACE_SCOPED_READ_OPERATION_SET = new Set<string>(WORKSPACE_SCOPED_READ_OPERATIONS);
+const WORKSPACE_SCOPED_CLIENT_CONTROL_SET = new Set<string>(WORKSPACE_SCOPED_CLIENT_CONTROLS);
+const UNIQUE_READ_OPERATION_MAP = {
+  findUnique: "findFirst",
+  findUniqueOrThrow: "findFirstOrThrow",
+} as const;
+
+export const MISSING_WORKSPACE_SCOPE_ERROR =
+  "workspaceId is required for workspace-scoped Prisma access.";
+export const CROSS_WORKSPACE_WRITE_ERROR = "Cross-workspace writes are not allowed.";
+export const UNSUPPORTED_WORKSPACE_UPSERT_ERROR =
+  "Workspace-scoped upsert is not supported; split it into explicit read/create or read/update flows.";
+
+const isRecordLike = (value: unknown): value is RecordLike =>
+  typeof value === "object" && value !== null;
+
+const isCallable = (value: unknown): value is UnknownFn =>
+  typeof value === "function";
+
+const cloneArgs = (args: unknown): Record<string, unknown> => {
+  if (!isRecordLike(args)) {
+    return {};
+  }
+
+  return { ...(args as Record<string, unknown>) };
+};
+
+const cloneData = (value: unknown) => {
+  if (!isRecordLike(value)) {
+    throw new Error("Workspace-scoped Prisma writes require an object payload.");
+  }
+
+  return { ...(value as Record<string, unknown>) };
+};
+
+export const requireWorkspaceId = (workspaceId: string) => {
+  const normalizedWorkspaceId = workspaceId.trim();
+  if (normalizedWorkspaceId.length === 0) {
+    throw new Error(MISSING_WORKSPACE_SCOPE_ERROR);
+  }
+
+  return normalizedWorkspaceId;
+};
+
+export const assertMatchingWorkspaceId = ({
+  expectedWorkspaceId,
+  actualWorkspaceId,
+}: {
+  expectedWorkspaceId: string;
+  actualWorkspaceId: string;
+}) => {
+  if (expectedWorkspaceId !== actualWorkspaceId) {
+    throw new Error(CROSS_WORKSPACE_WRITE_ERROR);
+  }
+};
+
+export const addWorkspaceScopeWhere = ({
+  workspaceId,
+  where,
+}: {
+  workspaceId: string;
+  where: unknown;
+}) => {
+  const normalizedWorkspaceId = requireWorkspaceId(workspaceId);
+
+  if (!isRecordLike(where) || Object.keys(where).length === 0) {
+    return { workspaceId: normalizedWorkspaceId };
+  }
+
+  return {
+    AND: [where, { workspaceId: normalizedWorkspaceId }],
+  };
+};
+
+const normalizeWorkspaceCreateData = ({
+  workspaceId,
+  data,
+}: {
+  workspaceId: string;
+  data: unknown;
+}) => {
+  const normalizedWorkspaceId = requireWorkspaceId(workspaceId);
+  const nextData = cloneData(data);
+
+  if ("workspaceId" in nextData && nextData.workspaceId !== normalizedWorkspaceId) {
+    throw new Error(CROSS_WORKSPACE_WRITE_ERROR);
+  }
+
+  return {
+    ...nextData,
+    workspaceId: normalizedWorkspaceId,
+  };
+};
+
+const normalizeWorkspaceCreateManyData = ({
+  workspaceId,
+  data,
+}: {
+  workspaceId: string;
+  data: unknown;
+}) => {
+  if (Array.isArray(data)) {
+    return data.map((entry) =>
+      normalizeWorkspaceCreateData({
+        workspaceId,
+        data: entry,
+      }),
+    );
+  }
+
+  return normalizeWorkspaceCreateData({
+    workspaceId,
+    data,
+  });
+};
+
+const normalizeWorkspaceUpdateData = ({
+  workspaceId,
+  data,
+}: {
+  workspaceId: string;
+  data: unknown;
+}) => {
+  const normalizedWorkspaceId = requireWorkspaceId(workspaceId);
+  const nextData = cloneData(data);
+
+  if ("workspaceId" in nextData && nextData.workspaceId !== normalizedWorkspaceId) {
+    throw new Error(CROSS_WORKSPACE_WRITE_ERROR);
+  }
+
+  return nextData;
+};
+
+export const normalizeWorkspaceScopedReadArgs = ({
+  workspaceId,
+  args,
+}: {
+  workspaceId: string;
+  args: unknown;
+}) => {
+  const nextArgs = cloneArgs(args);
+
+  nextArgs.where = addWorkspaceScopeWhere({
+    workspaceId,
+    where: nextArgs.where,
+  });
+
+  return nextArgs;
+};
+
+export const normalizeWorkspaceScopedCreateArgs = ({
+  workspaceId,
+  args,
+}: {
+  workspaceId: string;
+  args: unknown;
+}) => {
+  const nextArgs = cloneArgs(args);
+
+  nextArgs.data = normalizeWorkspaceCreateData({
+    workspaceId,
+    data: nextArgs.data,
+  });
+
+  return nextArgs;
+};
+
+export const normalizeWorkspaceScopedCreateManyArgs = ({
+  workspaceId,
+  args,
+}: {
+  workspaceId: string;
+  args: unknown;
+}) => {
+  const nextArgs = cloneArgs(args);
+
+  nextArgs.data = normalizeWorkspaceCreateManyData({
+    workspaceId,
+    data: nextArgs.data,
+  });
+
+  return nextArgs;
+};
+
+export const normalizeWorkspaceScopedUpdateManyArgs = ({
+  workspaceId,
+  args,
+}: {
+  workspaceId: string;
+  args: unknown;
+}) => {
+  const nextArgs = cloneArgs(args);
+
+  nextArgs.where = addWorkspaceScopeWhere({
+    workspaceId,
+    where: nextArgs.where,
+  });
+  if ("data" in nextArgs) {
+    nextArgs.data = normalizeWorkspaceUpdateData({
+      workspaceId,
+      data: nextArgs.data,
+    });
+  }
+
+  return nextArgs;
+};
+
+const normalizeWorkspaceScopedUpdateArgs = ({
+  workspaceId,
+  args,
+}: {
+  workspaceId: string;
+  args: unknown;
+}) => {
+  const nextArgs = cloneArgs(args);
+
+  if ("data" in nextArgs) {
+    nextArgs.data = normalizeWorkspaceUpdateData({
+      workspaceId,
+      data: nextArgs.data,
+    });
+  }
+
+  return nextArgs;
+};
+
+const resolveRequiredDelegateMethod = ({
+  target,
+  receiver,
+  methodName,
+  errorMessage,
+}: {
+  target: object;
+  receiver: object;
+  methodName: string;
+  errorMessage: string;
+}) => {
+  const delegateMethod = Reflect.get(target, methodName, receiver);
+  if (!isCallable(delegateMethod)) {
+    throw new Error(errorMessage);
+  }
+
+  return delegateMethod;
+};
+
+const createPassthroughHandler = ({
+  method,
+  target,
+}: {
+  method: (...args: unknown[]) => unknown;
+  target: object;
+}) =>
+  (...args: unknown[]) =>
+    Reflect.apply(method, target, args);
+
+const createReadOperationHandler = ({
+  method,
+  target,
+  workspaceId,
+}: {
+  method: (...args: unknown[]) => unknown;
+  target: object;
+  workspaceId: string;
+}) =>
+  (args?: unknown) =>
+    Reflect.apply(method, target, [
+      normalizeWorkspaceScopedReadArgs({
+        workspaceId,
+        args,
+      }),
+    ]);
+
+const createUniqueReadOperationHandler = ({
+  target,
+  receiver,
+  methodName,
+  workspaceId,
+}: {
+  target: object;
+  receiver: object;
+  methodName: "findFirst" | "findFirstOrThrow";
+  workspaceId: string;
+}) =>
+  (args?: unknown) =>
+    Reflect.apply(
+      resolveRequiredDelegateMethod({
+        target,
+        receiver,
+        methodName,
+        errorMessage: `Workspace scope proxy requires a ${methodName}() delegate method.`,
+      }),
+      target,
+      [
+        normalizeWorkspaceScopedReadArgs({
+          workspaceId,
+          args,
+        }),
+      ],
+    );
+
+const createMutationOperationHandler = ({
+  target,
+  receiver,
+  methodName,
+  errorMessage,
+  normalizeArgs,
+}: {
+  target: object;
+  receiver: object;
+  methodName: string;
+  errorMessage: string;
+  normalizeArgs: (args: unknown) => Record<string, unknown>;
+}) =>
+  (args?: unknown) =>
+    Reflect.apply(
+      resolveRequiredDelegateMethod({
+        target,
+        receiver,
+        methodName,
+        errorMessage,
+      }),
+      target,
+      [normalizeArgs(args)],
+    );
+
+const createGuardedUniqueMutationHandler = ({
+  property,
+  target,
+  receiver,
+  workspaceId,
+  normalizeArgs,
+}: {
+  property: "update" | "delete";
+  target: object;
+  receiver: object;
+  workspaceId: string;
+  normalizeArgs: (args: unknown) => Record<string, unknown>;
+}) =>
+  async (args?: unknown) => {
+    const nextArgs = cloneArgs(args);
+    const findFirst = resolveRequiredDelegateMethod({
+      target,
+      receiver,
+      methodName: "findFirst",
+      errorMessage: "Workspace scope proxy requires a findFirst() delegate method for unique mutations.",
+    });
+
+    const record = await Reflect.apply(findFirst, target, [
+      {
+        where: addWorkspaceScopeWhere({
+          workspaceId,
+          where: nextArgs.where,
+        }),
+        select: { id: true },
+      },
+    ]);
+
+    if (!record) {
+      throw new Error(
+        `Workspace-scoped ${property}() did not match an active record in workspace ${requireWorkspaceId(workspaceId)}.`,
+      );
+    }
+
+    return Reflect.apply(
+      resolveRequiredDelegateMethod({
+        target,
+        receiver,
+        methodName: property,
+        errorMessage: `Workspace scope proxy requires a ${property}() delegate method.`,
+      }),
+      target,
+      [normalizeArgs(nextArgs)],
+    );
+  };
+
+const resolveReadOperationHandler = ({
+  property,
+  target,
+  receiver,
+  value,
+  workspaceId,
+}: {
+  property: string;
+  target: object;
+  receiver: object;
+  value: UnknownFn;
+  workspaceId: string;
+}) => {
+  if (property === "findUnique" || property === "findUniqueOrThrow") {
+    return createUniqueReadOperationHandler({
+      target,
+      receiver,
+      methodName: UNIQUE_READ_OPERATION_MAP[property],
+      workspaceId,
+    });
+  }
+
+  if (WORKSPACE_SCOPED_READ_OPERATION_SET.has(property)) {
+    return createReadOperationHandler({
+      method: value,
+      target,
+      workspaceId,
+    });
+  }
+
+  return null;
+};
+
+const resolveWriteOperationHandler = ({
+  property,
+  target,
+  receiver,
+  workspaceId,
+}: {
+  property: string;
+  target: object;
+  receiver: object;
+  workspaceId: string;
+}) => {
+  if (property === "create") {
+    return createMutationOperationHandler({
+      target,
+      receiver,
+      methodName: "create",
+      errorMessage: "Workspace scope proxy requires a create() delegate method.",
+      normalizeArgs: (args) =>
+        normalizeWorkspaceScopedCreateArgs({
+          workspaceId,
+          args,
+        }),
+    });
+  }
+
+  if (property === "createMany") {
+    return createMutationOperationHandler({
+      target,
+      receiver,
+      methodName: "createMany",
+      errorMessage: "Workspace scope proxy requires a createMany() delegate method.",
+      normalizeArgs: (args) =>
+        normalizeWorkspaceScopedCreateManyArgs({
+          workspaceId,
+          args,
+        }),
+    });
+  }
+
+  if (property === "updateMany" || property === "deleteMany") {
+    return createMutationOperationHandler({
+      target,
+      receiver,
+      methodName: property,
+      errorMessage: `Workspace scope proxy requires a ${property}() delegate method.`,
+      normalizeArgs: (args) =>
+        normalizeWorkspaceScopedUpdateManyArgs({
+          workspaceId,
+          args,
+        }),
+    });
+  }
+
+  if (property === "update" || property === "delete") {
+    return createGuardedUniqueMutationHandler({
+      property,
+      target,
+      receiver,
+      workspaceId,
+      normalizeArgs: (args) =>
+        normalizeWorkspaceScopedUpdateArgs({
+          workspaceId,
+          args,
+        }),
+    });
+  }
+
+  if (property === "upsert") {
+    return () => {
+      throw new Error(UNSUPPORTED_WORKSPACE_UPSERT_ERROR);
+    };
+  }
+
+  return null;
+};
+
+const resolveDelegateProperty = ({
+  property,
+  value,
+  target,
+  receiver,
+  workspaceId,
+}: {
+  property: string;
+  value: unknown;
+  target: object;
+  receiver: object;
+  workspaceId: string;
+}) => {
+  if (!isCallable(value)) {
+    return value;
+  }
+
+  const readOperationHandler = resolveReadOperationHandler({
+    property,
+    target,
+    receiver,
+    value,
+    workspaceId,
+  });
+  if (readOperationHandler) {
+    return readOperationHandler;
+  }
+
+  const writeOperationHandler = resolveWriteOperationHandler({
+    property,
+    target,
+    receiver,
+    workspaceId,
+  });
+  if (writeOperationHandler) {
+    return writeOperationHandler;
+  }
+
+  return createPassthroughHandler({
+    method: value,
+    target,
+  });
+};
+
+const shouldWrapWorkspaceScopedDelegate = (property: string | symbol, value: unknown) =>
+  typeof property === "string" && WORKSPACE_SCOPED_MODEL_SET.has(property) && isRecordLike(value);
+
+export const createWorkspaceScopedDelegateProxy = <TDelegate extends object>(
+  delegate: TDelegate,
+  workspaceId: string,
+) =>
+  new Proxy(delegate, {
+    get(target, property, receiver) {
+      if (typeof property !== "string") {
+        return Reflect.get(target, property, receiver);
+      }
+
+      return resolveDelegateProperty({
+        property,
+        value: Reflect.get(target, property, receiver),
+        target,
+        receiver,
+        workspaceId,
+      });
+    },
+  });
+
+export const createWorkspaceScopedPrismaClient = <TClient extends object>(
+  client: TClient,
+  workspaceId: string,
+) => {
+  const normalizedWorkspaceId = requireWorkspaceId(workspaceId);
+
+  return new Proxy(client, {
+    get(target, property, receiver) {
+      if (typeof property === "string" && WORKSPACE_SCOPED_CLIENT_CONTROL_SET.has(property)) {
+        const control = Reflect.get(target, property, receiver);
+        if (isCallable(control)) {
+          return () =>
+            createWorkspaceScopedPrismaClient(
+              Reflect.apply(control, target, []) as TClient,
+              normalizedWorkspaceId,
+            );
+        }
+      }
+
+      const value = Reflect.get(target, property, receiver);
+      if (shouldWrapWorkspaceScopedDelegate(property, value)) {
+        return createWorkspaceScopedDelegateProxy(value as object, normalizedWorkspaceId);
+      }
+
+      return value;
+    },
+  });
+};

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "pnpm exec eslint . --max-warnings=0",
     "typecheck": "pnpm exec tsc -p packages/shared/tsconfig.json --noEmit && pnpm exec tsc -p packages/ui/tsconfig.json --noEmit && pnpm exec tsc -p packages/database/tsconfig.json --noEmit && pnpm --filter @collabsphere/web run typecheck",
     "test": "pnpm exec turbo run //#test:unit && pnpm exec turbo run //#test:integration --env-mode=loose",
-    "test:unit": "pnpm --filter @collabsphere/web run test:unit && pnpm exec tsx --test --test-concurrency=1 .github/scripts/story-project-gates.test.ts tests/unit/api-bootstrap-env.test.ts tests/unit/api-email-config.test.ts tests/unit/api-soft-delete-prisma.test.ts tests/unit/ci-workflow.test.ts tests/unit/collab-worker-bootstrap-env.test.ts tests/unit/integration-fixtures.test.ts tests/unit/shared-env.test.ts tests/unit/shared-prisma-enums.test.ts",
+    "test:unit": "pnpm --filter @collabsphere/web run test:unit && pnpm exec tsx --test --test-concurrency=1 .github/scripts/story-project-gates.test.ts tests/unit/api-bootstrap-env.test.ts tests/unit/api-email-config.test.ts tests/unit/api-soft-delete-prisma.test.ts tests/unit/api-workspace-scope-prisma.test.ts tests/unit/ci-workflow.test.ts tests/unit/collab-worker-bootstrap-env.test.ts tests/unit/integration-fixtures.test.ts tests/unit/shared-env.test.ts tests/unit/shared-prisma-enums.test.ts",
     "test:integration": "node --test tests/integration",
     "build": "pnpm exec turbo run build",
     "build:web": "pnpm --filter @collabsphere/web run build",

--- a/tests/unit/api-soft-delete-prisma.test.ts
+++ b/tests/unit/api-soft-delete-prisma.test.ts
@@ -113,7 +113,9 @@ test("soft delete normalizes delete operations into update payloads", () => {
       now: fixedNow,
     }),
     {
-      where: { id: "user_123" },
+      where: {
+        AND: [{ id: "user_123" }, { deletedAt: null }],
+      },
       data: {
         deletedAt: fixedDeletedAt,
       },
@@ -176,7 +178,9 @@ test("default client turns delete and deleteMany into soft-delete updates", asyn
     {
       method: "update",
       args: {
-        where: { id: "user_123" },
+        where: {
+          AND: [{ id: "user_123" }, { deletedAt: null }],
+        },
         data: {
           deletedAt: fixedDeletedAt,
         },
@@ -231,6 +235,37 @@ test("purge client keeps hard deletes available while default client still filte
   });
   assert.deepEqual(purgeDeleteArgs, {
     where: { id: "user_123" },
+  });
+});
+
+test("withDeleted delete still only targets active rows", async () => {
+  let updateArgs: unknown;
+  const prisma = createSoftDeletePrismaClient(
+    {
+      user: {
+        delete: async () => ({ id: "user_123" }),
+        update: async (args?: unknown) => {
+          updateArgs = args;
+          return { id: "user_123" };
+        },
+      },
+    },
+    {
+      now: fixedNow,
+    },
+  );
+
+  await prisma.$withDeleted().user.delete({
+    where: { id: "user_123" },
+  });
+
+  assert.deepEqual(updateArgs, {
+    where: {
+      AND: [{ id: "user_123" }, { deletedAt: null }],
+    },
+    data: {
+      deletedAt: fixedDeletedAt,
+    },
   });
 });
 

--- a/tests/unit/api-workspace-scope-prisma.test.ts
+++ b/tests/unit/api-workspace-scope-prisma.test.ts
@@ -7,10 +7,7 @@ import {
   createWorkspaceScopedPrismaClient,
   CROSS_WORKSPACE_WRITE_ERROR,
   MISSING_WORKSPACE_SCOPE_ERROR,
-  normalizeWorkspaceScopedCreateArgs,
-  normalizeWorkspaceScopedCreateManyArgs,
-  normalizeWorkspaceScopedReadArgs,
-  normalizeWorkspaceScopedUpdateManyArgs,
+  normalizeWorkspaceScopedArgs,
   requireWorkspaceId,
   UNSUPPORTED_WORKSPACE_UNIQUE_MUTATION_ERROR,
   UNSUPPORTED_WORKSPACE_UPSERT_ERROR,
@@ -50,11 +47,12 @@ test("workspace scope normalizes where and create payloads", () => {
   );
 
   assert.deepEqual(
-    normalizeWorkspaceScopedReadArgs({
+    normalizeWorkspaceScopedArgs({
       workspaceId: "ws_123",
       args: {
         where: { status: "todo" },
       },
+      operation: "read",
     }),
     {
       where: {
@@ -64,11 +62,12 @@ test("workspace scope normalizes where and create payloads", () => {
   );
 
   assert.deepEqual(
-    normalizeWorkspaceScopedCreateArgs({
+    normalizeWorkspaceScopedArgs({
       workspaceId: "ws_123",
       args: {
         data: { title: "Scoped task", workspaceId: undefined },
       },
+      operation: "create",
     }),
     {
       data: {
@@ -79,12 +78,13 @@ test("workspace scope normalizes where and create payloads", () => {
   );
 
   assert.deepEqual(
-    normalizeWorkspaceScopedUpdateManyArgs({
+    normalizeWorkspaceScopedArgs({
       workspaceId: "ws_123",
       args: {
         where: { status: "todo" },
         data: { isRead: true },
       },
+      operation: "updateMany",
     }),
     {
       where: {
@@ -100,7 +100,7 @@ test("workspace scope normalizes where and create payloads", () => {
 test("workspace scope rejects createMany payloads that try to cross workspace boundaries", () => {
   assert.throws(
     () =>
-      normalizeWorkspaceScopedCreateManyArgs({
+      normalizeWorkspaceScopedArgs({
         workspaceId: "ws_123",
         args: {
           data: [
@@ -108,6 +108,7 @@ test("workspace scope rejects createMany payloads that try to cross workspace bo
             { title: "invalid row", workspaceId: "ws_other" },
           ],
         },
+        operation: "createMany",
       }),
     {
       message: CROSS_WORKSPACE_WRITE_ERROR,
@@ -220,12 +221,13 @@ test("workspace-scoped create injects workspaceId and withDeleted preserves the 
 
 test("workspace-scoped updateMany strips workspaceId from payloads and scopes the where clause", () => {
   assert.deepEqual(
-    normalizeWorkspaceScopedUpdateManyArgs({
+    normalizeWorkspaceScopedArgs({
       workspaceId: "ws_123",
       args: {
         where: { status: "todo" },
         data: { title: "Updated task", workspaceId: undefined },
       },
+      operation: "updateMany",
     }),
     {
       where: {

--- a/tests/unit/api-workspace-scope-prisma.test.ts
+++ b/tests/unit/api-workspace-scope-prisma.test.ts
@@ -240,6 +240,35 @@ test("workspace-scoped updateMany strips workspaceId from payloads and scopes th
   );
 });
 
+test("workspace-scoped deleteMany only scopes the where clause", async () => {
+  let updateManyArgs: unknown;
+  const prisma = createPrismaService({
+    task: {
+      deleteMany: async () => ({ count: 2 }),
+      updateMany: async (args?: unknown) => {
+        updateManyArgs = args;
+        return { count: 2 };
+      },
+    },
+  });
+
+  await withWorkspaceScope(prisma, "ws_123").task.deleteMany({
+    where: { status: "done" },
+  });
+
+  assert.deepEqual((updateManyArgs as { where: unknown }).where, {
+    AND: [
+      {
+        AND: [{ status: "done" }, { workspaceId: "ws_123" }],
+      },
+      { deletedAt: null },
+    ],
+  });
+  assert.ok(
+    (updateManyArgs as { data: { deletedAt: unknown } }).data.deletedAt instanceof Date,
+  );
+});
+
 test("workspace-scoped unique mutations are rejected because Prisma cannot scope them atomically", () => {
   const scopedClient = createWorkspaceScopedPrismaClient(
     {
@@ -285,10 +314,10 @@ test("workspace-scoped upsert is rejected until the call sites are split into ex
   assert.throws(
     () =>
       scopedClient.task.upsert({
-      where: { id: "task_123" },
-      create: { title: "Scoped task" },
-      update: { title: "Updated task" },
-    }),
+        where: { id: "task_123" },
+        create: { title: "Scoped task" },
+        update: { title: "Updated task" },
+      }),
     {
       message: UNSUPPORTED_WORKSPACE_UPSERT_ERROR,
     },

--- a/tests/unit/api-workspace-scope-prisma.test.ts
+++ b/tests/unit/api-workspace-scope-prisma.test.ts
@@ -12,6 +12,7 @@ import {
   normalizeWorkspaceScopedReadArgs,
   normalizeWorkspaceScopedUpdateManyArgs,
   requireWorkspaceId,
+  UNSUPPORTED_WORKSPACE_UNIQUE_MUTATION_ERROR,
   UNSUPPORTED_WORKSPACE_UPSERT_ERROR,
 } from "../../apps/api/src/common/prisma/workspace-scope.js";
 import {
@@ -66,7 +67,7 @@ test("workspace scope normalizes where and create payloads", () => {
     normalizeWorkspaceScopedCreateArgs({
       workspaceId: "ws_123",
       args: {
-        data: { title: "Scoped task" },
+        data: { title: "Scoped task", workspaceId: undefined },
       },
     }),
     {
@@ -217,30 +218,56 @@ test("workspace-scoped create injects workspaceId and withDeleted preserves the 
   });
 });
 
-test("workspace-scoped unique mutations reject records outside the requested workspace", async () => {
-  let updateCalled = false;
-  const baseClient = {
-    task: {
-      findFirst: async () => null,
-      update: async () => {
-        updateCalled = true;
-        return { id: "task_123" };
+test("workspace-scoped updateMany strips workspaceId from payloads and scopes the where clause", () => {
+  assert.deepEqual(
+    normalizeWorkspaceScopedUpdateManyArgs({
+      workspaceId: "ws_123",
+      args: {
+        where: { status: "todo" },
+        data: { title: "Updated task", workspaceId: undefined },
       },
-    },
-  };
-
-  const prisma = createPrismaService(baseClient);
-
-  await assert.rejects(
-    withWorkspaceScope(prisma, "ws_123").task.update({
-      where: { id: "task_123" },
-      data: { title: "Updated task" },
     }),
     {
-      message: "Workspace-scoped update() did not match an active record in workspace ws_123.",
+      where: {
+        AND: [{ status: "todo" }, { workspaceId: "ws_123" }],
+      },
+      data: {
+        title: "Updated task",
+      },
     },
   );
-  assert.equal(updateCalled, false);
+});
+
+test("workspace-scoped unique mutations are rejected because Prisma cannot scope them atomically", () => {
+  const scopedClient = createWorkspaceScopedPrismaClient(
+    {
+      task: {
+        update: async () => ({ id: "task_123" }),
+        delete: async () => ({ id: "task_123" }),
+      },
+    },
+    "ws_123",
+  );
+
+  assert.throws(
+    () =>
+      scopedClient.task.update({
+        where: { id: "task_123" },
+        data: { title: "Updated task" },
+      }),
+    {
+      message: UNSUPPORTED_WORKSPACE_UNIQUE_MUTATION_ERROR,
+    },
+  );
+  assert.throws(
+    () =>
+      scopedClient.task.delete({
+        where: { id: "task_123" },
+      }),
+    {
+      message: UNSUPPORTED_WORKSPACE_UNIQUE_MUTATION_ERROR,
+    },
+  );
 });
 
 test("workspace-scoped upsert is rejected until the call sites are split into explicit flows", () => {

--- a/tests/unit/api-workspace-scope-prisma.test.ts
+++ b/tests/unit/api-workspace-scope-prisma.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
@@ -9,6 +10,7 @@ import {
   MISSING_WORKSPACE_SCOPE_ERROR,
   normalizeWorkspaceScopedArgs,
   requireWorkspaceId,
+  WORKSPACE_SCOPED_TABLES,
   UNSUPPORTED_WORKSPACE_UNIQUE_MUTATION_ERROR,
   UNSUPPORTED_WORKSPACE_UPSERT_ERROR,
 } from "../../apps/api/src/common/prisma/workspace-scope.js";
@@ -114,6 +116,15 @@ test("workspace scope rejects createMany payloads that try to cross workspace bo
       message: CROSS_WORKSPACE_WRITE_ERROR,
     },
   );
+});
+
+test("workspace scope docs stay aligned with the scoped table catalog", () => {
+  const contributing = readFileSync(new URL("../../CONTRIBUTING.md", import.meta.url), "utf8");
+  for (const tableName of WORKSPACE_SCOPED_TABLES) {
+    assert.match(contributing, new RegExp(`\\\`${tableName}\\\``));
+  }
+
+  assert.match(contributing, /notifications` is a mixed-scope table/);
 });
 
 test("workspace-scoped reads compose with the default soft-delete filter", async () => {

--- a/tests/unit/api-workspace-scope-prisma.test.ts
+++ b/tests/unit/api-workspace-scope-prisma.test.ts
@@ -1,0 +1,267 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  addWorkspaceScopeWhere,
+  assertMatchingWorkspaceId,
+  createWorkspaceScopedPrismaClient,
+  CROSS_WORKSPACE_WRITE_ERROR,
+  MISSING_WORKSPACE_SCOPE_ERROR,
+  normalizeWorkspaceScopedCreateArgs,
+  normalizeWorkspaceScopedCreateManyArgs,
+  normalizeWorkspaceScopedReadArgs,
+  normalizeWorkspaceScopedUpdateManyArgs,
+  requireWorkspaceId,
+  UNSUPPORTED_WORKSPACE_UPSERT_ERROR,
+} from "../../apps/api/src/common/prisma/workspace-scope.js";
+import {
+  createPrismaService,
+  withDeletedRecords,
+  withWorkspaceScope,
+} from "../../apps/api/src/common/prisma/prisma.service.js";
+
+test("workspace helpers reject empty scope values and mismatched cross-workspace writes", () => {
+  assert.throws(() => requireWorkspaceId("  "), {
+    message: MISSING_WORKSPACE_SCOPE_ERROR,
+  });
+
+  assert.throws(
+    () =>
+      assertMatchingWorkspaceId({
+        expectedWorkspaceId: "ws_alpha",
+        actualWorkspaceId: "ws_beta",
+      }),
+    {
+      message: CROSS_WORKSPACE_WRITE_ERROR,
+    },
+  );
+});
+
+test("workspace scope normalizes where and create payloads", () => {
+  assert.deepEqual(
+    addWorkspaceScopeWhere({
+      workspaceId: "ws_123",
+      where: { status: "todo" },
+    }),
+    {
+      AND: [{ status: "todo" }, { workspaceId: "ws_123" }],
+    },
+  );
+
+  assert.deepEqual(
+    normalizeWorkspaceScopedReadArgs({
+      workspaceId: "ws_123",
+      args: {
+        where: { status: "todo" },
+      },
+    }),
+    {
+      where: {
+        AND: [{ status: "todo" }, { workspaceId: "ws_123" }],
+      },
+    },
+  );
+
+  assert.deepEqual(
+    normalizeWorkspaceScopedCreateArgs({
+      workspaceId: "ws_123",
+      args: {
+        data: { title: "Scoped task" },
+      },
+    }),
+    {
+      data: {
+        title: "Scoped task",
+        workspaceId: "ws_123",
+      },
+    },
+  );
+
+  assert.deepEqual(
+    normalizeWorkspaceScopedUpdateManyArgs({
+      workspaceId: "ws_123",
+      args: {
+        where: { status: "todo" },
+        data: { isRead: true },
+      },
+    }),
+    {
+      where: {
+        AND: [{ status: "todo" }, { workspaceId: "ws_123" }],
+      },
+      data: {
+        isRead: true,
+      },
+    },
+  );
+});
+
+test("workspace scope rejects createMany payloads that try to cross workspace boundaries", () => {
+  assert.throws(
+    () =>
+      normalizeWorkspaceScopedCreateManyArgs({
+        workspaceId: "ws_123",
+        args: {
+          data: [
+            { title: "valid row" },
+            { title: "invalid row", workspaceId: "ws_other" },
+          ],
+        },
+      }),
+    {
+      message: CROSS_WORKSPACE_WRITE_ERROR,
+    },
+  );
+});
+
+test("workspace-scoped reads compose with the default soft-delete filter", async () => {
+  let capturedArgs: unknown;
+  const baseClient = {
+    task: {
+      findMany: async (args?: unknown) => {
+        capturedArgs = args;
+        return [];
+      },
+    },
+  };
+
+  const prisma = createPrismaService(baseClient);
+
+  await withWorkspaceScope(prisma, "ws_123").task.findMany({
+    where: { status: "todo" },
+  });
+
+  assert.deepEqual(capturedArgs, {
+    where: {
+      AND: [
+        {
+          AND: [{ status: "todo" }, { workspaceId: "ws_123" }],
+        },
+        { deletedAt: null },
+      ],
+    },
+  });
+});
+
+test("workspace-scoped findUnique delegates to findFirst so filters remain valid", async () => {
+  const calls: Array<{ method: string; args: unknown }> = [];
+  const baseClient = {
+    task: {
+      findUnique: async () => ({ id: "task_123" }),
+      findFirst: async (args?: unknown) => {
+        calls.push({ method: "findFirst", args });
+        return { id: "task_123" };
+      },
+    },
+  };
+
+  const prisma = createPrismaService(baseClient);
+
+  await withWorkspaceScope(prisma, "ws_123").task.findUnique({
+    where: { id: "task_123" },
+  });
+
+  assert.deepEqual(calls, [
+    {
+      method: "findFirst",
+      args: {
+        where: {
+          AND: [
+            {
+              AND: [{ id: "task_123" }, { workspaceId: "ws_123" }],
+            },
+            { deletedAt: null },
+          ],
+        },
+      },
+    },
+  ]);
+});
+
+test("workspace-scoped create injects workspaceId and withDeleted preserves the scope", async () => {
+  let createArgs: unknown;
+  let withDeletedReadArgs: unknown;
+  const baseClient = {
+    task: {
+      create: async (args?: unknown) => {
+        createArgs = args;
+        return { id: "task_123" };
+      },
+      findMany: async (args?: unknown) => {
+        withDeletedReadArgs = args;
+        return [];
+      },
+    },
+  };
+
+  const prisma = createPrismaService(baseClient);
+  const scopedClient = withWorkspaceScope(prisma, "ws_123");
+
+  await scopedClient.task.create({
+    data: { title: "Scoped task" },
+  });
+  await withDeletedRecords(scopedClient).task.findMany({
+    where: { status: "todo" },
+  });
+
+  assert.deepEqual(createArgs, {
+    data: {
+      title: "Scoped task",
+      workspaceId: "ws_123",
+    },
+  });
+  assert.deepEqual(withDeletedReadArgs, {
+    where: {
+      AND: [{ status: "todo" }, { workspaceId: "ws_123" }],
+    },
+  });
+});
+
+test("workspace-scoped unique mutations reject records outside the requested workspace", async () => {
+  let updateCalled = false;
+  const baseClient = {
+    task: {
+      findFirst: async () => null,
+      update: async () => {
+        updateCalled = true;
+        return { id: "task_123" };
+      },
+    },
+  };
+
+  const prisma = createPrismaService(baseClient);
+
+  await assert.rejects(
+    withWorkspaceScope(prisma, "ws_123").task.update({
+      where: { id: "task_123" },
+      data: { title: "Updated task" },
+    }),
+    {
+      message: "Workspace-scoped update() did not match an active record in workspace ws_123.",
+    },
+  );
+  assert.equal(updateCalled, false);
+});
+
+test("workspace-scoped upsert is rejected until the call sites are split into explicit flows", () => {
+  const scopedClient = createWorkspaceScopedPrismaClient(
+    {
+      task: {
+        upsert: async () => ({ id: "task_123" }),
+      },
+    },
+    "ws_123",
+  );
+
+  assert.throws(
+    () =>
+      scopedClient.task.upsert({
+      where: { id: "task_123" },
+      create: { title: "Scoped task" },
+      update: { title: "Updated task" },
+    }),
+    {
+      message: UNSUPPORTED_WORKSPACE_UPSERT_ERROR,
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- add workspace-scoped Prisma helper proxies for workspace-owned models
- document workspace scoping conventions and the current table coverage list
- add unit coverage and wire the new workspace-scope tests into the repo and API scripts
- carry forward the remaining soft-delete delete-guard fix from PR #1579 so default and $withDeleted() deletes only target active rows

## Linked Issues
Closes #42
Closes #315
Closes #316
Closes #317
Closes #318
Closes #319
Closes #320
Closes #321
Closes #1185

## Handoff
- [x] Handoff added to the linked issue or parent story

## Validation
- pnpm prisma validate
- pnpm lint
- pnpm typecheck
- pnpm test:unit
- pnpm build
- docker compose exec -T postgres psql -U collab -d collabsphere -v ON_ERROR_STOP=1 -c "INSERT INTO task_columns (id, name, status, position, created_at, updated_at) VALUES (gen_random_uuid(), 'Todo', 'todo', 1, now(), now());" -> expected NOT NULL failure on workspace_id
- pnpm --filter @collabsphere/api test still shows the existing Windows-local bootstrap artifact race, but the same API suite passed inside the serialized pnpm test:unit run

## Notes
- DB-side workspace_id columns, foreign keys, and partial indexes were already present on main in the initial schema migration; this PR completes the missing API helper, docs, validation closure, and test layer for CS-022.
- pnpm review:coderabbit could not run because the CodeRabbit CLI rejected the repo surface as too large: 1001 files, which is 851 over the 150-file limit.