### PR TITLE
feat(api): implement CS-024 error envelopes

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,6 +6,6 @@
   "scripts": {
     "dev": "tsx watch src/dev.ts",
     "build": "pnpm exec tsc -p tsconfig.json && tsx ../../scripts/build-bootstrap-app.ts .",
-    "test": "pnpm exec tsx --test --test-concurrency=1 ../../tests/unit/api-bootstrap-env.test.ts ../../tests/unit/api-email-config.test.ts ../../tests/unit/api-response-envelope.test.ts ../../tests/unit/api-soft-delete-prisma.test.ts ../../tests/unit/api-workspace-scope-prisma.test.ts"
+    "test": "pnpm exec tsx --test --test-concurrency=1 ../../tests/unit/api-bootstrap-env.test.ts ../../tests/unit/api-email-config.test.ts ../../tests/unit/api-error-filter.test.ts ../../tests/unit/api-response-envelope.test.ts ../../tests/unit/api-soft-delete-prisma.test.ts ../../tests/unit/api-workspace-scope-prisma.test.ts"
   }
 }

--- a/apps/api/src/common/errors/error-sanitizer.ts
+++ b/apps/api/src/common/errors/error-sanitizer.ts
@@ -130,6 +130,21 @@ const sanitizeValidationDetails = (details: ValidationErrorDetail[] | undefined)
     rule: detail.rule,
   }));
 
+const isAlwaysSanitizedServerError = (code: CanonicalErrorCode) =>
+  code === "DATABASE_ERROR" || code === "INTERNAL_ERROR";
+
+const sanitizeValidationPayload = ({
+  message,
+  details,
+}: Pick<ErrorEnvelopePayload, "message" | "details">): SanitizedErrorEnvelopePayload => ({
+  message: containsSensitiveContent(message) ? defaultErrorMessages.VALIDATION_ERROR : message,
+  details: sanitizeValidationDetails(details),
+});
+
+const sanitizeServerErrorPayload = (code: CanonicalErrorCode): SanitizedErrorEnvelopePayload => ({
+  message: getDefaultErrorMessage(code),
+});
+
 export const getDefaultErrorMessage = (code: CanonicalErrorCode) => defaultErrorMessages[code];
 
 export const sanitizeErrorEnvelopePayload = ({
@@ -137,19 +152,19 @@ export const sanitizeErrorEnvelopePayload = ({
   message,
   details,
 }: ErrorEnvelopePayload): SanitizedErrorEnvelopePayload => {
-  const defaultMessage = getDefaultErrorMessage(code);
-
   if (code === "VALIDATION_ERROR") {
-    return {
-      message: containsSensitiveContent(message) ? defaultMessage : message,
-      details: sanitizeValidationDetails(details),
-    };
+    return sanitizeValidationPayload({
+      message,
+      details,
+    });
   }
 
-  if (code === "DATABASE_ERROR" || code === "INTERNAL_ERROR" || containsSensitiveContent(message)) {
-    return {
-      message: defaultMessage,
-    };
+  if (isAlwaysSanitizedServerError(code)) {
+    return sanitizeServerErrorPayload(code);
+  }
+
+  if (containsSensitiveContent(message)) {
+    return sanitizeServerErrorPayload(code);
   }
 
   return {

--- a/apps/api/src/common/errors/error-sanitizer.ts
+++ b/apps/api/src/common/errors/error-sanitizer.ts
@@ -14,7 +14,7 @@ type SanitizedErrorEnvelopePayload = {
 
 const sqlPattern =
   /\b(select|insert|update|delete|drop|alter|create|truncate)\b[\s\S]*\b(from|into|table|values|set)\b/i;
-const prismaPattern = /\bprisma(client)?\b/i;
+const prismaPattern = /\bprisma(?:client)?\w*\b/i;
 const secretPattern = /\b(password|secret|token|api[_-]?key|authorization)\b/i;
 const internalIdPattern =
   /\b(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|(?:user|workspace|document|task|file|member|invitation|export)_\w+)\b/i;

--- a/apps/api/src/common/errors/error-sanitizer.ts
+++ b/apps/api/src/common/errors/error-sanitizer.ts
@@ -1,0 +1,158 @@
+import type { CanonicalErrorCode } from "../filters/app-error.filter.js";
+import type { ValidationErrorDetail } from "./validation-errors.js";
+
+type ErrorEnvelopePayload = {
+  code: CanonicalErrorCode;
+  message: string;
+  details?: ValidationErrorDetail[];
+};
+
+type SanitizedErrorEnvelopePayload = {
+  message: string;
+  details?: ValidationErrorDetail[];
+};
+
+const sqlPattern =
+  /\b(select|insert|update|delete|drop|alter|create|truncate)\b[\s\S]*\b(from|into|table|values|set)\b/i;
+const prismaPattern = /\bprisma(client)?\b/i;
+const secretPattern = /\b(password|secret|token|api[_-]?key|authorization)\b/i;
+const internalIdPattern =
+  /\b(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|(?:user|workspace|document|task|file|member|invitation|export)_\w+)\b/i;
+
+const containsSensitiveContent = (value: string) =>
+  sqlPattern.test(value) ||
+  prismaPattern.test(value) ||
+  secretPattern.test(value) ||
+  internalIdPattern.test(value);
+
+const defaultErrorMessages: Record<CanonicalErrorCode, string> = {
+  VALIDATION_ERROR: "Validation failed",
+  INVALID_EMAIL: "Invalid email address",
+  PASSWORD_TOO_WEAK: "Password does not meet complexity requirements",
+  INVALID_CREDENTIALS: "Invalid credentials",
+  PASSWORD_SAME_AS_CURRENT: "New password must differ from current password",
+  INVALID_DATE: "Invalid date value",
+  INVALID_ENUM_VALUE: "Invalid value for the provided field",
+  INVALID_JSON: "Malformed JSON request body",
+  INVALID_ANCHOR: "Invalid anchor payload",
+  INVALID_MENTION: "Mentioned user is not valid",
+  INVALID_ASSIGNEE: "Invalid assignee",
+  INVALID_LABEL: "Invalid label",
+  INVALID_PARENT: "Invalid parent",
+  INVALID_NEW_OWNER: "Invalid new owner",
+  INVALID_FILE_TYPE: "File type not allowed",
+  FILE_TOO_LARGE: "File exceeds maximum size",
+  CHECKSUM_MISMATCH: "File checksum mismatch",
+  TEMPLATE_CATEGORY_MISMATCH: "Template category mismatch",
+  TEMPLATE_INVALID: "Template invalid",
+  TEMPLATE_SCHEMA_UNSUPPORTED: "Template schema unsupported",
+  UNAUTHORIZED: "Authentication required",
+  TOKEN_EXPIRED: "Token expired",
+  TOKEN_INVALID: "Invalid token",
+  REFRESH_TOKEN_MISSING: "Refresh token missing",
+  REFRESH_TOKEN_INVALID: "Refresh token invalid",
+  OAUTH_INVALID_CALLBACK: "OAuth callback invalid",
+  OAUTH_STATE_MISMATCH: "OAuth security check failed",
+  FORBIDDEN: "You do not have permission to perform this action",
+  NOT_WORKSPACE_MEMBER: "You are not a member of this workspace",
+  INSUFFICIENT_ROLE: "Insufficient role for this action",
+  FORBIDDEN_ROLE_ASSIGNMENT: "You cannot assign this role",
+  ACCOUNT_DEACTIVATED: "Account deactivated",
+  EMAIL_NOT_VERIFIED: "Email not verified",
+  EDIT_WINDOW_EXPIRED: "Comment edit window expired",
+  WORKSPACE_ARCHIVED_READONLY: "Workspace is archived (read-only)",
+  WORKSPACE_NOT_ACADEMIC: "Workspace is not academic",
+  OAUTH_USER_NO_PASSWORD: "Password managed by OAuth provider",
+  DOCUMENT_LOCKED: "Document is locked",
+  DOCUMENT_READONLY_STATUS: "Document is read-only in its current status",
+  TEMPLATE_DISABLED: "Template disabled",
+  EMAIL_MISMATCH: "This invitation was sent to a different email address",
+  ADMIN_ONLY: "Admin access required",
+  NOT_FOUND: "Resource not found",
+  WORKSPACE_NOT_FOUND: "Workspace not found",
+  DOCUMENT_NOT_FOUND: "Document not found",
+  TASK_NOT_FOUND: "Task not found",
+  FOLDER_NOT_FOUND: "Folder not found",
+  INVITATION_NOT_FOUND: "Invitation not found",
+  MEMBER_NOT_FOUND: "Member not found",
+  TEMPLATE_NOT_FOUND: "Template not found",
+  FILE_NOT_FOUND: "File not found",
+  EXPORT_JOB_NOT_FOUND: "Export job not found",
+  LINK_NOT_FOUND: "Link not found",
+  TARGET_NOT_FOUND: "Target not found",
+  EMAIL_ALREADY_EXISTS: "Email already exists",
+  ACCOUNT_EXISTS_LOCAL: "Account exists with local auth",
+  ACCOUNT_EXISTS_OAUTH: "Account exists with OAuth provider",
+  ACCOUNT_EXISTS_OTHER_PROVIDER: "Account exists with another provider",
+  WORKSPACE_NAME_CONFLICT: "Workspace name already used",
+  ALREADY_MEMBER: "You are already a member",
+  ATTACHMENT_EXISTS: "Attachment already exists",
+  CONCURRENT_MODIFICATION: "Resource was modified by another user",
+  IDEMPOTENCY_CONFLICT: "Idempotency key conflict",
+  RATE_LIMITED: "Too many requests. Please try again later.",
+  INVALID_TRANSITION: "Invalid status transition",
+  INVALID_STATUS: "Invalid resource status for this operation",
+  CANNOT_DEMOTE_OWNER: "Cannot demote owner",
+  CANNOT_REMOVE_OWNER: "Cannot remove owner",
+  CANNOT_LEAVE_AS_OWNER: "Cannot leave as owner",
+  NO_SUPERVISOR_ASSIGNED: "Supervisor not assigned",
+  DOCUMENT_EMPTY: "Document must contain content",
+  NOTE_REQUIRED: "Feedback note required",
+  FOLDER_NOT_EMPTY: "Folder is not empty",
+  FILE_NOT_READY: "File not ready for download or attach",
+  UPLOAD_NOT_FOUND_IN_STORAGE: "Upload not found in storage",
+  WORKSPACE_MISMATCH: "Workspace mismatch",
+  WORKSPACE_LIMIT_REACHED: "Workspace limit reached",
+  WORKSPACE_MEMBER_LIMIT_REACHED: "Workspace member limit reached",
+  WORKSPACE_STORAGE_LIMIT_REACHED: "Workspace storage limit reached",
+  TASK_LIMIT_REACHED: "Task limit reached",
+  DOCUMENT_LIMIT_REACHED: "Document limit reached",
+  INVITATION_EXPIRED: "Invitation expired",
+  INVITATION_ALREADY_USED: "Invitation already used",
+  TOKEN_ALREADY_USED: "Token already used",
+  SERVICE_UNAVAILABLE: "Service unavailable",
+  EMAIL_PROVIDER_UNAVAILABLE: "Email service unavailable",
+  OAUTH_PROVIDER_UNAVAILABLE: "OAuth provider unavailable",
+  STORAGE_UNAVAILABLE: "Storage service unavailable",
+  COLLAB_SERVICE_UNAVAILABLE: "Collaboration service unavailable",
+  INTERNAL_ERROR: "Unexpected server error",
+  DATABASE_ERROR: "Database operation failed",
+  TEMPLATE_APPLICATION_FAILED: "Template application failed",
+  EXPORT_FAILED: "Export failed",
+};
+
+const sanitizeValidationDetails = (details: ValidationErrorDetail[] | undefined) =>
+  details?.map((detail) => ({
+    field: detail.field,
+    message: containsSensitiveContent(detail.message)
+      ? defaultErrorMessages.VALIDATION_ERROR
+      : detail.message,
+    rule: detail.rule,
+  }));
+
+export const getDefaultErrorMessage = (code: CanonicalErrorCode) => defaultErrorMessages[code];
+
+export const sanitizeErrorEnvelopePayload = ({
+  code,
+  message,
+  details,
+}: ErrorEnvelopePayload): SanitizedErrorEnvelopePayload => {
+  const defaultMessage = getDefaultErrorMessage(code);
+
+  if (code === "VALIDATION_ERROR") {
+    return {
+      message: containsSensitiveContent(message) ? defaultMessage : message,
+      details: sanitizeValidationDetails(details),
+    };
+  }
+
+  if (code === "DATABASE_ERROR" || code === "INTERNAL_ERROR" || containsSensitiveContent(message)) {
+    return {
+      message: defaultMessage,
+    };
+  }
+
+  return {
+    message,
+  };
+};

--- a/apps/api/src/common/errors/error-sanitizer.ts
+++ b/apps/api/src/common/errors/error-sanitizer.ts
@@ -19,11 +19,11 @@ const secretPattern = /\b(password|secret|token|api[_-]?key|authorization)\b/i;
 const internalIdPattern =
   /\b(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|(?:user|workspace|document|task|file|member|invitation|export)_\w+)\b/i;
 
+const containsSensitiveValidationContent = (value: string) =>
+  sqlPattern.test(value) || prismaPattern.test(value) || internalIdPattern.test(value);
+
 const containsSensitiveContent = (value: string) =>
-  sqlPattern.test(value) ||
-  prismaPattern.test(value) ||
-  secretPattern.test(value) ||
-  internalIdPattern.test(value);
+  containsSensitiveValidationContent(value) || secretPattern.test(value);
 
 const defaultErrorMessages: Record<CanonicalErrorCode, string> = {
   VALIDATION_ERROR: "Validation failed",
@@ -124,7 +124,7 @@ const defaultErrorMessages: Record<CanonicalErrorCode, string> = {
 const sanitizeValidationDetails = (details: ValidationErrorDetail[] | undefined) =>
   details?.map((detail) => ({
     field: detail.field,
-    message: containsSensitiveContent(detail.message)
+    message: containsSensitiveValidationContent(detail.message)
       ? defaultErrorMessages.VALIDATION_ERROR
       : detail.message,
     rule: detail.rule,

--- a/apps/api/src/common/errors/validation-errors.ts
+++ b/apps/api/src/common/errors/validation-errors.ts
@@ -1,0 +1,37 @@
+export type ValidationErrorDetail = {
+  field: string;
+  message: string;
+  rule: string;
+};
+
+export type ValidationErrorIssue = {
+  field: string;
+  message: string;
+  rule?: string;
+};
+
+const defaultValidationRule = "invalid";
+
+const normalizeValidationField = (field: string) => {
+  const trimmed = field.trim();
+  return trimmed.length > 0 ? trimmed : "unknown";
+};
+
+const normalizeValidationMessage = (message: string) => {
+  const trimmed = message.trim();
+  return trimmed.length > 0 ? trimmed : "Validation failed";
+};
+
+const normalizeValidationRule = (rule?: string) => {
+  const trimmed = rule?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : defaultValidationRule;
+};
+
+export const createValidationErrorDetails = (
+  issues: readonly ValidationErrorIssue[],
+): ValidationErrorDetail[] =>
+  issues.map((issue) => ({
+    field: normalizeValidationField(issue.field),
+    message: normalizeValidationMessage(issue.message),
+    rule: normalizeValidationRule(issue.rule),
+  }));

--- a/apps/api/src/common/filters/app-error.filter.ts
+++ b/apps/api/src/common/filters/app-error.filter.ts
@@ -1,0 +1,395 @@
+import { inspect } from "node:util";
+import {
+  getDefaultErrorMessage,
+  sanitizeErrorEnvelopePayload,
+} from "../errors/error-sanitizer.js";
+import {
+  createValidationErrorDetails,
+  type ValidationErrorDetail,
+  type ValidationErrorIssue,
+} from "../errors/validation-errors.js";
+
+const validationErrorCodes = [
+  "VALIDATION_ERROR",
+  "INVALID_EMAIL",
+  "PASSWORD_TOO_WEAK",
+  "INVALID_CREDENTIALS",
+  "PASSWORD_SAME_AS_CURRENT",
+  "INVALID_DATE",
+  "INVALID_ENUM_VALUE",
+  "INVALID_JSON",
+  "INVALID_ANCHOR",
+  "INVALID_MENTION",
+  "INVALID_ASSIGNEE",
+  "INVALID_LABEL",
+  "INVALID_PARENT",
+  "INVALID_NEW_OWNER",
+  "INVALID_FILE_TYPE",
+  "FILE_TOO_LARGE",
+  "CHECKSUM_MISMATCH",
+  "TEMPLATE_CATEGORY_MISMATCH",
+  "TEMPLATE_INVALID",
+  "TEMPLATE_SCHEMA_UNSUPPORTED",
+] as const;
+
+const authenticationErrorCodes = [
+  "UNAUTHORIZED",
+  "TOKEN_EXPIRED",
+  "TOKEN_INVALID",
+  "REFRESH_TOKEN_MISSING",
+  "REFRESH_TOKEN_INVALID",
+  "OAUTH_INVALID_CALLBACK",
+  "OAUTH_STATE_MISMATCH",
+] as const;
+
+const authorizationErrorCodes = [
+  "FORBIDDEN",
+  "NOT_WORKSPACE_MEMBER",
+  "INSUFFICIENT_ROLE",
+  "FORBIDDEN_ROLE_ASSIGNMENT",
+  "ACCOUNT_DEACTIVATED",
+  "EMAIL_NOT_VERIFIED",
+  "EDIT_WINDOW_EXPIRED",
+  "WORKSPACE_ARCHIVED_READONLY",
+  "WORKSPACE_NOT_ACADEMIC",
+  "OAUTH_USER_NO_PASSWORD",
+  "DOCUMENT_LOCKED",
+  "DOCUMENT_READONLY_STATUS",
+  "TEMPLATE_DISABLED",
+  "EMAIL_MISMATCH",
+  "ADMIN_ONLY",
+] as const;
+
+const notFoundErrorCodes = [
+  "NOT_FOUND",
+  "WORKSPACE_NOT_FOUND",
+  "DOCUMENT_NOT_FOUND",
+  "TASK_NOT_FOUND",
+  "FOLDER_NOT_FOUND",
+  "INVITATION_NOT_FOUND",
+  "MEMBER_NOT_FOUND",
+  "TEMPLATE_NOT_FOUND",
+  "FILE_NOT_FOUND",
+  "EXPORT_JOB_NOT_FOUND",
+  "LINK_NOT_FOUND",
+  "TARGET_NOT_FOUND",
+] as const;
+
+const conflictErrorCodes = [
+  "EMAIL_ALREADY_EXISTS",
+  "ACCOUNT_EXISTS_LOCAL",
+  "ACCOUNT_EXISTS_OAUTH",
+  "ACCOUNT_EXISTS_OTHER_PROVIDER",
+  "WORKSPACE_NAME_CONFLICT",
+  "ALREADY_MEMBER",
+  "ATTACHMENT_EXISTS",
+  "CONCURRENT_MODIFICATION",
+  "IDEMPOTENCY_CONFLICT",
+] as const;
+
+const rateLimitErrorCodes = ["RATE_LIMITED"] as const;
+
+const workflowErrorCodes = [
+  "INVALID_TRANSITION",
+  "INVALID_STATUS",
+  "CANNOT_DEMOTE_OWNER",
+  "CANNOT_REMOVE_OWNER",
+  "CANNOT_LEAVE_AS_OWNER",
+  "NO_SUPERVISOR_ASSIGNED",
+  "DOCUMENT_EMPTY",
+  "NOTE_REQUIRED",
+  "FOLDER_NOT_EMPTY",
+  "FILE_NOT_READY",
+  "UPLOAD_NOT_FOUND_IN_STORAGE",
+  "WORKSPACE_MISMATCH",
+  "WORKSPACE_LIMIT_REACHED",
+  "WORKSPACE_MEMBER_LIMIT_REACHED",
+  "WORKSPACE_STORAGE_LIMIT_REACHED",
+  "TASK_LIMIT_REACHED",
+  "DOCUMENT_LIMIT_REACHED",
+  "INVITATION_EXPIRED",
+  "INVITATION_ALREADY_USED",
+  "TOKEN_ALREADY_USED",
+] as const;
+
+const externalDependencyErrorCodes = [
+  "SERVICE_UNAVAILABLE",
+  "EMAIL_PROVIDER_UNAVAILABLE",
+  "OAUTH_PROVIDER_UNAVAILABLE",
+  "STORAGE_UNAVAILABLE",
+  "COLLAB_SERVICE_UNAVAILABLE",
+] as const;
+
+const internalErrorCodes = [
+  "INTERNAL_ERROR",
+  "DATABASE_ERROR",
+  "TEMPLATE_APPLICATION_FAILED",
+  "EXPORT_FAILED",
+] as const;
+
+export type CanonicalErrorCode =
+  | (typeof validationErrorCodes)[number]
+  | (typeof authenticationErrorCodes)[number]
+  | (typeof authorizationErrorCodes)[number]
+  | (typeof notFoundErrorCodes)[number]
+  | (typeof conflictErrorCodes)[number]
+  | (typeof rateLimitErrorCodes)[number]
+  | (typeof workflowErrorCodes)[number]
+  | (typeof externalDependencyErrorCodes)[number]
+  | (typeof internalErrorCodes)[number];
+
+const errorStatusByCode: Record<CanonicalErrorCode, number> = {
+  VALIDATION_ERROR: 400,
+  INVALID_EMAIL: 400,
+  PASSWORD_TOO_WEAK: 400,
+  INVALID_CREDENTIALS: 400,
+  PASSWORD_SAME_AS_CURRENT: 400,
+  INVALID_DATE: 400,
+  INVALID_ENUM_VALUE: 400,
+  INVALID_JSON: 400,
+  INVALID_ANCHOR: 400,
+  INVALID_MENTION: 400,
+  INVALID_ASSIGNEE: 400,
+  INVALID_LABEL: 400,
+  INVALID_PARENT: 400,
+  INVALID_NEW_OWNER: 400,
+  INVALID_FILE_TYPE: 400,
+  FILE_TOO_LARGE: 400,
+  CHECKSUM_MISMATCH: 400,
+  TEMPLATE_CATEGORY_MISMATCH: 400,
+  TEMPLATE_INVALID: 400,
+  TEMPLATE_SCHEMA_UNSUPPORTED: 400,
+  UNAUTHORIZED: 401,
+  TOKEN_EXPIRED: 401,
+  TOKEN_INVALID: 401,
+  REFRESH_TOKEN_MISSING: 401,
+  REFRESH_TOKEN_INVALID: 401,
+  OAUTH_INVALID_CALLBACK: 401,
+  OAUTH_STATE_MISMATCH: 401,
+  FORBIDDEN: 403,
+  NOT_WORKSPACE_MEMBER: 403,
+  INSUFFICIENT_ROLE: 403,
+  FORBIDDEN_ROLE_ASSIGNMENT: 403,
+  ACCOUNT_DEACTIVATED: 403,
+  EMAIL_NOT_VERIFIED: 403,
+  EDIT_WINDOW_EXPIRED: 403,
+  WORKSPACE_ARCHIVED_READONLY: 403,
+  WORKSPACE_NOT_ACADEMIC: 403,
+  OAUTH_USER_NO_PASSWORD: 403,
+  DOCUMENT_LOCKED: 403,
+  DOCUMENT_READONLY_STATUS: 403,
+  TEMPLATE_DISABLED: 403,
+  EMAIL_MISMATCH: 403,
+  ADMIN_ONLY: 403,
+  NOT_FOUND: 404,
+  WORKSPACE_NOT_FOUND: 404,
+  DOCUMENT_NOT_FOUND: 404,
+  TASK_NOT_FOUND: 404,
+  FOLDER_NOT_FOUND: 404,
+  INVITATION_NOT_FOUND: 404,
+  MEMBER_NOT_FOUND: 404,
+  TEMPLATE_NOT_FOUND: 404,
+  FILE_NOT_FOUND: 404,
+  EXPORT_JOB_NOT_FOUND: 404,
+  LINK_NOT_FOUND: 404,
+  TARGET_NOT_FOUND: 404,
+  EMAIL_ALREADY_EXISTS: 409,
+  ACCOUNT_EXISTS_LOCAL: 409,
+  ACCOUNT_EXISTS_OAUTH: 409,
+  ACCOUNT_EXISTS_OTHER_PROVIDER: 409,
+  WORKSPACE_NAME_CONFLICT: 409,
+  ALREADY_MEMBER: 409,
+  ATTACHMENT_EXISTS: 409,
+  CONCURRENT_MODIFICATION: 409,
+  IDEMPOTENCY_CONFLICT: 409,
+  RATE_LIMITED: 429,
+  INVALID_TRANSITION: 400,
+  INVALID_STATUS: 400,
+  CANNOT_DEMOTE_OWNER: 400,
+  CANNOT_REMOVE_OWNER: 400,
+  CANNOT_LEAVE_AS_OWNER: 400,
+  NO_SUPERVISOR_ASSIGNED: 400,
+  DOCUMENT_EMPTY: 400,
+  NOTE_REQUIRED: 400,
+  FOLDER_NOT_EMPTY: 400,
+  FILE_NOT_READY: 400,
+  UPLOAD_NOT_FOUND_IN_STORAGE: 400,
+  WORKSPACE_MISMATCH: 400,
+  WORKSPACE_LIMIT_REACHED: 400,
+  WORKSPACE_MEMBER_LIMIT_REACHED: 400,
+  WORKSPACE_STORAGE_LIMIT_REACHED: 400,
+  TASK_LIMIT_REACHED: 400,
+  DOCUMENT_LIMIT_REACHED: 400,
+  INVITATION_EXPIRED: 400,
+  INVITATION_ALREADY_USED: 400,
+  TOKEN_ALREADY_USED: 400,
+  SERVICE_UNAVAILABLE: 503,
+  EMAIL_PROVIDER_UNAVAILABLE: 503,
+  OAUTH_PROVIDER_UNAVAILABLE: 503,
+  STORAGE_UNAVAILABLE: 503,
+  COLLAB_SERVICE_UNAVAILABLE: 503,
+  INTERNAL_ERROR: 500,
+  DATABASE_ERROR: 500,
+  TEMPLATE_APPLICATION_FAILED: 500,
+  EXPORT_FAILED: 500,
+};
+
+export type ErrorEnvelope = {
+  error: {
+    code: CanonicalErrorCode;
+    message: string;
+    details?: ValidationErrorDetail[];
+    requestId: string;
+    timestamp: string;
+  };
+};
+
+type AppErrorOptions = {
+  code: CanonicalErrorCode;
+  message?: string;
+  statusCode?: number;
+  details?: ValidationErrorDetail[];
+  cause?: unknown;
+};
+
+type CreateValidationAppErrorOptions = {
+  message?: string;
+  issues: readonly ValidationErrorIssue[];
+  cause?: unknown;
+};
+
+type NormalizedAppError = {
+  code: CanonicalErrorCode;
+  message: string;
+  details?: ValidationErrorDetail[];
+  statusCode: number;
+  originalError: unknown;
+};
+
+type CreateErrorResponseOptions = {
+  error: unknown;
+  requestId: string;
+  timestamp?: string;
+};
+
+type CreateErrorResponseResult = {
+  statusCode: number;
+  payload: ErrorEnvelope;
+  normalizedError: NormalizedAppError;
+};
+
+const databaseErrorPattern =
+  /\bprisma(?:client)?\w*\b|\b(postgres|database|sql|query|relation|column)\b/i;
+
+export class AppError extends Error {
+  readonly code: CanonicalErrorCode;
+  readonly details?: ValidationErrorDetail[];
+  readonly statusCode: number;
+
+  constructor({ code, message, statusCode, details, cause }: AppErrorOptions) {
+    super(message ?? getDefaultErrorMessage(code), cause ? { cause } : undefined);
+    this.name = "AppError";
+    this.code = code;
+    this.details = details;
+    this.statusCode = statusCode ?? errorStatusByCode[code];
+  }
+}
+
+export class ValidationAppError extends AppError {
+  constructor({ message = "Validation failed", issues, cause }: CreateValidationAppErrorOptions) {
+    super({
+      code: "VALIDATION_ERROR",
+      message,
+      details: createValidationErrorDetails(issues),
+      cause,
+    });
+    this.name = "ValidationAppError";
+  }
+}
+
+const getErrorMessage = (error: unknown) => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return typeof error === "string" ? error : inspect(error, { depth: 5 });
+};
+
+const resolveUnknownErrorCode = (error: unknown): CanonicalErrorCode => {
+  const message = getErrorMessage(error);
+  return databaseErrorPattern.test(message) ? "DATABASE_ERROR" : "INTERNAL_ERROR";
+};
+
+const normalizeAppError = (error: unknown): NormalizedAppError => {
+  if (error instanceof AppError) {
+    return {
+      code: error.code,
+      message: error.message,
+      details: error.details,
+      statusCode: error.statusCode,
+      originalError: error.cause ?? error,
+    };
+  }
+
+  const code = resolveUnknownErrorCode(error);
+  return {
+    code,
+    message: getDefaultErrorMessage(code),
+    statusCode: errorStatusByCode[code],
+    originalError: error,
+  };
+};
+
+const formatLogPayload = (error: unknown) => {
+  if (error instanceof Error) {
+    return error.stack ?? error.message;
+  }
+
+  return inspect(error, { depth: 5 });
+};
+
+export const createErrorResponse = ({
+  error,
+  requestId,
+  timestamp = new Date().toISOString(),
+}: CreateErrorResponseOptions): CreateErrorResponseResult => {
+  const normalizedError = normalizeAppError(error);
+  const sanitized = sanitizeErrorEnvelopePayload({
+    code: normalizedError.code,
+    message: normalizedError.message,
+    details: normalizedError.details,
+  });
+
+  return {
+    statusCode: normalizedError.statusCode,
+    normalizedError,
+    payload: {
+      error: {
+        code: normalizedError.code,
+        message: sanitized.message,
+        ...(sanitized.details ? { details: sanitized.details } : {}),
+        requestId,
+        timestamp,
+      },
+    },
+  };
+};
+
+export const logApiError = ({
+  requestId,
+  normalizedError,
+}: {
+  requestId: string;
+  normalizedError: NormalizedAppError;
+}) => {
+  const logLine =
+    `[api] request failed (${requestId}) ` +
+    `[${normalizedError.code}] ${formatLogPayload(normalizedError.originalError)}`;
+
+  if (normalizedError.statusCode >= 500) {
+    console.error(logLine);
+    return;
+  }
+
+  console.warn(logLine);
+};

--- a/apps/api/src/dev.ts
+++ b/apps/api/src/dev.ts
@@ -3,6 +3,12 @@ import { randomUUID } from "node:crypto";
 import { EnvValidationError, parseApiRuntimeEnv } from "../../../packages/shared/src/api-env.js";
 import { resolveEmailConfig } from "./config/email.js";
 import {
+  AppError,
+  createErrorResponse,
+  logApiError,
+  ValidationAppError,
+} from "./common/filters/app-error.filter.js";
+import {
   type SuccessResponsePayload,
   wrapSuccessResponse,
 } from "./common/interceptors/response-envelope.interceptor.js";
@@ -60,6 +66,18 @@ const writeSuccessJson = (
     requestId,
   );
 
+const writeErrorJson = (response: ServerResponse, error: unknown, requestId: string) => {
+  const { statusCode, payload, normalizedError } = createErrorResponse({
+    error,
+    requestId,
+  });
+  logApiError({
+    requestId,
+    normalizedError,
+  });
+  return writeJson(response, statusCode, payload, requestId);
+};
+
 const createRequestId = () => `req_${randomUUID()}`;
 const { healthController } = createHealthModule({
   databaseUrl: apiEnv.DATABASE_URL,
@@ -74,18 +92,20 @@ const server = createServer((request: IncomingMessage, response: ServerResponse)
 
     try {
       url = new URL(request.url ?? "/", "http://bootstrap");
-    } catch {
-      return writeJson(
+    } catch (error) {
+      return writeErrorJson(
         response,
-        400,
-        {
-          error: {
-            code: "VALIDATION_ERROR",
-            message: "Invalid request URL",
-            requestId,
-            timestamp: new Date().toISOString()
-          }
-        },
+        new ValidationAppError({
+          message: "Invalid request URL",
+          issues: [
+            {
+              field: "url",
+              message: "Invalid request URL",
+              rule: "isUrl",
+            },
+          ],
+          cause: error,
+        }),
         requestId,
       );
     }
@@ -95,36 +115,16 @@ const server = createServer((request: IncomingMessage, response: ServerResponse)
       return writeSuccessJson(response, healthResponse.statusCode, healthResponse.payload, requestId);
     }
 
-    return writeJson(
+    return writeErrorJson(
       response,
-      404,
-      {
-        error: {
-          code: "NOT_FOUND",
-          message: `No bootstrap route for ${request.method} ${url.pathname}`,
-          requestId,
-          timestamp: new Date().toISOString()
-        }
-      },
+      new AppError({
+        code: "NOT_FOUND",
+        message: `No bootstrap route for ${request.method} ${url.pathname}`,
+      }),
       requestId,
     );
   })().catch((error: unknown) => {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(`[api] bootstrap request failed (${requestId}): ${message}`);
-
-    writeJson(
-      response,
-      500,
-      {
-        error: {
-          code: "INTERNAL_ERROR",
-          message: "Unexpected server error",
-          requestId,
-          timestamp: new Date().toISOString(),
-        },
-      },
-      requestId,
-    );
+    writeErrorJson(response, error, requestId);
   });
 });
 

--- a/docs/agent-ref/api/README.md
+++ b/docs/agent-ref/api/README.md
@@ -85,6 +85,31 @@ Action response:
 }
 ```
 
+## Error Envelope Example
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Validation failed",
+    "details": [
+      {
+        "field": "title",
+        "message": "Title is required",
+        "rule": "isNotEmpty"
+      }
+    ],
+    "requestId": "req_abc123",
+    "timestamp": "2025-07-17T12:00:00Z"
+  }
+}
+```
+
+Error rules:
+- `error.code` must come from the canonical catalog in `docs/spec/12-errors/12.4-error-code-catalog.md`.
+- `error.requestId` must always be present.
+- `error.details` is only for validation failures.
+- Never expose stack traces, SQL text, secrets, or internal identifiers in client responses.
+
 ## Edge Cases / Failure Modes
 - Authenticated non-member workspace access returns `403 NOT_WORKSPACE_MEMBER` consistently.
 - Admin endpoints require global role `ADMIN`.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "pnpm exec eslint . --max-warnings=0",
     "typecheck": "pnpm exec tsc -p packages/shared/tsconfig.json --noEmit && pnpm exec tsc -p packages/ui/tsconfig.json --noEmit && pnpm exec tsc -p packages/database/tsconfig.json --noEmit && pnpm --filter @collabsphere/web run typecheck",
     "test": "pnpm exec turbo run //#test:unit && pnpm exec turbo run //#test:integration --env-mode=loose",
-    "test:unit": "pnpm --filter @collabsphere/web run test:unit && pnpm exec tsx --test --test-concurrency=1 .github/scripts/story-project-gates.test.ts tests/unit/api-bootstrap-env.test.ts tests/unit/api-email-config.test.ts tests/unit/api-response-envelope.test.ts tests/unit/api-soft-delete-prisma.test.ts tests/unit/api-workspace-scope-prisma.test.ts tests/unit/ci-workflow.test.ts tests/unit/collab-worker-bootstrap-env.test.ts tests/unit/integration-fixtures.test.ts tests/unit/shared-env.test.ts tests/unit/shared-prisma-enums.test.ts",
+    "test:unit": "pnpm --filter @collabsphere/web run test:unit && pnpm exec tsx --test --test-concurrency=1 .github/scripts/story-project-gates.test.ts tests/unit/api-bootstrap-env.test.ts tests/unit/api-email-config.test.ts tests/unit/api-error-filter.test.ts tests/unit/api-response-envelope.test.ts tests/unit/api-soft-delete-prisma.test.ts tests/unit/api-workspace-scope-prisma.test.ts tests/unit/ci-workflow.test.ts tests/unit/collab-worker-bootstrap-env.test.ts tests/unit/integration-fixtures.test.ts tests/unit/shared-env.test.ts tests/unit/shared-prisma-enums.test.ts",
     "test:integration": "node --test tests/integration",
     "build": "pnpm exec turbo run build",
     "build:web": "pnpm --filter @collabsphere/web run build",

--- a/tests/unit/api-bootstrap-env.test.ts
+++ b/tests/unit/api-bootstrap-env.test.ts
@@ -163,6 +163,41 @@ const getBootstrapHealthResponse = async ({
   }
 };
 
+const withBootstrappedApi = async (
+  callback: (context: {
+    request: (pathName?: string) => ReturnType<typeof getJson>;
+    stderr: () => string;
+  }) => Promise<void>,
+  {
+    spawn = spawnApi,
+    envOverrides = validApiEnv,
+  }: {
+    spawn?: (envOverrides: NodeJS.ProcessEnv) => ReturnType<typeof spawnBootstrap>;
+    envOverrides?: NodeJS.ProcessEnv;
+  } = {},
+) => {
+  const child = spawn(envOverrides);
+  const stdoutText = collectStream(child.stdout);
+  const stderrText = collectStream(child.stderr);
+
+  try {
+    const match = await waitForStdoutMatch(
+      child,
+      stdoutText,
+      /bootstrap listening on http:\/\/[^:]+:(\d+)\/api\/v1\/health/,
+      "API bootstrap readiness",
+    );
+    const port = Number.parseInt(match[1], 10);
+
+    await callback({
+      request: (pathName = "/api/v1/health") => getJson(port, pathName),
+      stderr: stderrText,
+    });
+  } finally {
+    await stopChild(child);
+  }
+};
+
 const getHealthEnvelope = (response: HealthResponse) => {
   const body = response.body as {
     data?: {
@@ -261,6 +296,39 @@ test("built API bootstrap artifact stays runnable without monorepo source import
         ...dependencyEnv,
       },
     });
+  });
+});
+
+test("unknown bootstrap routes return the canonical error envelope with requestId", async () => {
+  await withMockDependencies(async (dependencyEnv) => {
+    await withBootstrappedApi(
+      async ({ request }) => {
+        const response = await request("/api/v1/missing");
+        const body = response.body as {
+          error?: {
+            code?: string;
+            message?: string;
+            requestId?: string;
+            timestamp?: string;
+          };
+        };
+        const requestIdHeader = getRequestIdHeader(response);
+
+        assert.equal(response.statusCode, 404);
+        assert.ok(body.error);
+        assert.equal(body.error.code, "NOT_FOUND");
+        assert.equal(body.error.message, "No bootstrap route for GET /api/v1/missing");
+        assert.match(body.error.requestId ?? "", /^req_/);
+        assert.equal(requestIdHeader, body.error.requestId);
+        assert.match(body.error.timestamp ?? "", /^\d{4}-\d{2}-\d{2}T/);
+      },
+      {
+        envOverrides: {
+          ...validApiEnv,
+          ...dependencyEnv,
+        },
+      },
+    );
   });
 });
 

--- a/tests/unit/api-error-filter.test.ts
+++ b/tests/unit/api-error-filter.test.ts
@@ -35,6 +35,30 @@ test("validation issues are normalized to canonical detail objects", () => {
   );
 });
 
+test("validation detail sanitization preserves field-name words like password", () => {
+  const { payload } = createErrorResponse({
+    error: new ValidationAppError({
+      issues: [
+        {
+          field: "password",
+          message: "Password is required",
+          rule: "isNotEmpty",
+        },
+      ],
+    }),
+    requestId: "req_password",
+    timestamp: "2026-04-24T00:00:00.000Z",
+  });
+
+  assert.deepEqual(payload.error.details, [
+    {
+      field: "password",
+      message: "Password is required",
+      rule: "isNotEmpty",
+    },
+  ]);
+});
+
 test("validation app errors return canonical validation envelopes", () => {
   const { statusCode, payload } = createErrorResponse({
     error: new ValidationAppError({

--- a/tests/unit/api-error-filter.test.ts
+++ b/tests/unit/api-error-filter.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  AppError,
+  createErrorResponse,
+  ValidationAppError,
+} from "../../apps/api/src/common/filters/app-error.filter.ts";
+import { createValidationErrorDetails } from "../../apps/api/src/common/errors/validation-errors.ts";
+
+test("validation issues are normalized to canonical detail objects", () => {
+  assert.deepEqual(
+    createValidationErrorDetails([
+      {
+        field: " title ",
+        message: " Title is required ",
+        rule: " isNotEmpty ",
+      },
+      {
+        field: "",
+        message: "",
+      },
+    ]),
+    [
+      {
+        field: "title",
+        message: "Title is required",
+        rule: "isNotEmpty",
+      },
+      {
+        field: "unknown",
+        message: "Validation failed",
+        rule: "invalid",
+      },
+    ],
+  );
+});
+
+test("validation app errors return canonical validation envelopes", () => {
+  const { statusCode, payload } = createErrorResponse({
+    error: new ValidationAppError({
+      issues: [
+        {
+          field: "title",
+          message: "Title is required",
+          rule: "isNotEmpty",
+        },
+      ],
+    }),
+    requestId: "req_validation",
+    timestamp: "2026-04-24T00:00:00.000Z",
+  });
+
+  assert.equal(statusCode, 400);
+  assert.deepEqual(payload, {
+    error: {
+      code: "VALIDATION_ERROR",
+      message: "Validation failed",
+      details: [
+        {
+          field: "title",
+          message: "Title is required",
+          rule: "isNotEmpty",
+        },
+      ],
+      requestId: "req_validation",
+      timestamp: "2026-04-24T00:00:00.000Z",
+    },
+  });
+});
+
+test("known app errors preserve safe client messages", () => {
+  const { statusCode, payload } = createErrorResponse({
+    error: new AppError({
+      code: "NOT_FOUND",
+      message: "No bootstrap route for GET /api/v1/missing",
+    }),
+    requestId: "req_not_found",
+    timestamp: "2026-04-24T00:00:00.000Z",
+  });
+
+  assert.equal(statusCode, 404);
+  assert.deepEqual(payload, {
+    error: {
+      code: "NOT_FOUND",
+      message: "No bootstrap route for GET /api/v1/missing",
+      requestId: "req_not_found",
+      timestamp: "2026-04-24T00:00:00.000Z",
+    },
+  });
+});
+
+test("database-like unexpected errors are sanitized for clients", () => {
+  const { statusCode, payload } = createErrorResponse({
+    error: new Error(
+      'PrismaClientKnownRequestError: SELECT * FROM "users" WHERE id = \'user_123\' failed',
+    ),
+    requestId: "req_db",
+    timestamp: "2026-04-24T00:00:00.000Z",
+  });
+
+  assert.equal(statusCode, 500);
+  assert.deepEqual(payload, {
+    error: {
+      code: "DATABASE_ERROR",
+      message: "Database operation failed",
+      requestId: "req_db",
+      timestamp: "2026-04-24T00:00:00.000Z",
+    },
+  });
+});
+
+test("unknown unexpected errors fall back to INTERNAL_ERROR", () => {
+  const { statusCode, payload } = createErrorResponse({
+    error: new Error("kaboom"),
+    requestId: "req_internal",
+    timestamp: "2026-04-24T00:00:00.000Z",
+  });
+
+  assert.equal(statusCode, 500);
+  assert.deepEqual(payload, {
+    error: {
+      code: "INTERNAL_ERROR",
+      message: "Unexpected server error",
+      requestId: "req_internal",
+      timestamp: "2026-04-24T00:00:00.000Z",
+    },
+  });
+});

--- a/tests/unit/api-error-filter.test.ts
+++ b/tests/unit/api-error-filter.test.ts
@@ -4,8 +4,8 @@ import {
   AppError,
   createErrorResponse,
   ValidationAppError,
-} from "../../apps/api/src/common/filters/app-error.filter.ts";
-import { createValidationErrorDetails } from "../../apps/api/src/common/errors/validation-errors.ts";
+} from "../../apps/api/src/common/filters/app-error.filter.js";
+import { createValidationErrorDetails } from "../../apps/api/src/common/errors/validation-errors.js";
 
 test("validation issues are normalized to canonical detail objects", () => {
   assert.deepEqual(


### PR DESCRIPTION
## Summary
- add reusable API error helpers for canonical code mapping, validation details, and client-safe sanitization
- route bootstrap API errors through a single error-envelope path that always emits `requestId` and timestamp
- document the canonical error envelope and add unit/bootstrap coverage for 404, validation, and database/internal failures

## Validation
- [x] `pnpm --filter @collabsphere/api test`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm test:unit`

## Review Notes
- CS-024 task guidance references Nest `main.ts`, but the current API surface still boots from `apps/api/src/dev.ts`; the reusable filter logic was added under `apps/api/src/common` and wired through the bootstrap entrypoint instead of inventing a dead `main.ts`.
- Carry-forward Devin findings from the prior API PRs are already present on `main`; this PR builds on that corrected baseline.

## Linked Issues
Closes #44
Closes #326
Closes #327
Closes #328
Closes #329
Closes #1186

## Handoff
- [ ] Handoff not required for this PR
- [x] Handoff added to the linked issue or parent story

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rick1330/collabsphere/pull/1582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
